### PR TITLE
7: Removed the timed and now message retrieval messages API methods for MessageRetriever

### DIFF
--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/retriever/MessageRetriever.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/retriever/MessageRetriever.java
@@ -22,16 +22,6 @@ import javax.validation.constraints.NotNull;
 @ThreadSafe
 public interface MessageRetriever {
     /**
-     * Retrieve a message from the queue now if there are any available.
-     *
-     * <p>This will not keep waiting until a message is placed onto the queue.
-     *
-     * @return the optional message obtained from the queue
-     * @throws InterruptedException if the thread was interrupted while waiting for a message
-     */
-    Optional<Message> retrieveMessageNow() throws InterruptedException;
-
-    /**
      * Retrieve a single message from the queue and if there are no messages currently in the queue it will keep polling until a message eventually is
      * retrieved.
      *
@@ -41,21 +31,4 @@ public interface MessageRetriever {
      * @throws InterruptedException if the thread was interrupted while waiting for a message
      */
     Message retrieveMessage() throws InterruptedException;
-
-    /**
-     * Retrieve a single message from the queue within the given time period.
-     *
-     * <p>This is a blocking operation so it will wait until a message can be taken from the queue within the given period. Note that this operation may
-     * not perfectly align with the requested timeout due to implementation or other processing concerns, therefore the timeout should just be considered
-     * as a suggestion.  However, implementers of this method should always strive to being as close to the timeout as possible.
-     *
-     * <p>The timeout amount must always be greater than or equal to zero. If a negative number is submitted a {@link IllegalArgumentException} will be thrown.
-     *
-     * @param timeout  the number of time units to wait, e.g. 5 of "5 seconds"
-     * @param timeUnit the unit of time for the timeout, e.g. seconds of "5 seconds"
-     * @return the message to process if there is any or {@link Optional#empty()} if none was obtained in the time period
-     * @throws IllegalArgumentException if the arguments are in an incorrect format
-     * @throws InterruptedException if the thread was interrupted while waiting for a message
-     */
-    Optional<Message> retrieveMessage(@Min(0) long timeout, @NotNull TimeUnit timeUnit) throws InterruptedException;
 }

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetriever.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetriever.java
@@ -39,70 +39,29 @@ public class IndividualMessageRetriever implements MessageRetriever {
     private final IndividualMessageRetrieverProperties properties;
 
     @Override
-    public Optional<Message> retrieveMessageNow() throws InterruptedException {
-        return retrieveMessage(0, MILLISECONDS);
-    }
-
-    @Override
     public Message retrieveMessage() throws InterruptedException {
-        Optional<Message> optionalMessage = Optional.empty();
-        while (!optionalMessage.isPresent()) {
-            optionalMessage = retrieveMessage(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS, SECONDS);
-        }
+        final Message message;
+        while (true) {
+            final Future<ReceiveMessageResult> receiveMessageResultFuture = amazonSqsAsync.receiveMessageAsync(generateReceiveMessageRequest());
 
-        return optionalMessage.get();
-    }
-
-    /**
-     * As the {@link ReceiveMessageRequest#waitTimeSeconds} is to seconds the timeout for this method will be to the closest second and therefore milliseconds
-     * will be ignored. The timeout also doesn't take into account latency for the request so the actual wait time will not perfectly align with what is
-     * requested but will be close.
-     */
-    @Override
-    public Optional<Message> retrieveMessage(@Min(0) final long timeout, @NotNull final TimeUnit timeUnit) throws InterruptedException {
-        Preconditions.checkArgument(timeout >= 0, "timeout should be greater than or equal to zero");
-        Preconditions.checkNotNull(timeUnit, "timeUnit");
-
-        final int secondsToWait = toIntExact(timeUnit.toSeconds(timeout));
-        return retrieveMessage(secondsToWait);
-    }
-
-    /**
-     * Wait the total provided seconds to receive a message from a queue.
-     *
-     * <p>As {@link ReceiveMessageRequest#waitTimeSeconds} has a maximum value multiple calls will be made be made until the total time has elapsed.
-     *
-     * @param totalSecondsToWait the total number of seconds to wait for the message
-     * @return the message if it was successfully received or an {@link Optional#empty()} if no message was received within the period
-     * @throws InterruptedException if the thread was interrupted while waiting for the message
-     */
-    private Optional<Message> retrieveMessage(final int totalSecondsToWait) throws InterruptedException {
-        final int waitTimeInSecondsForThisRequest = Math.min(totalSecondsToWait, MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS);
-
-        final Future<ReceiveMessageResult> receiveMessageResultFuture = amazonSqsAsync.receiveMessageAsync(
-                generateReceiveMessageRequest(waitTimeInSecondsForThisRequest)
-        );
-
-        try {
-            final ReceiveMessageResult receiveMessageResult = receiveMessageResultFuture.get();
-            if (!receiveMessageResult.getMessages().isEmpty()) {
-                return Optional.of(receiveMessageResult.getMessages().get(0));
+            try {
+                final ReceiveMessageResult receiveMessageResult = receiveMessageResultFuture.get();
+                if (!receiveMessageResult.getMessages().isEmpty()) {
+                    message = receiveMessageResult.getMessages().get(0);
+                    break;
+                }
+            } catch (final ExecutionException executionException) {
+                throw new RuntimeException("Exception retrieving message", executionException.getCause());
             }
-        } catch (final ExecutionException executionException) {
-            throw new RuntimeException("Exception retrieving message", executionException.getCause());
         }
 
-        final int newSecondsToWait = totalSecondsToWait - waitTimeInSecondsForThisRequest;
-        if (newSecondsToWait <= 0) {
-            return Optional.empty();
-        }
-        return retrieveMessage(newSecondsToWait);
+        return message;
     }
 
-    private ReceiveMessageRequest generateReceiveMessageRequest(final int waitTimeInSeconds) {
+    private ReceiveMessageRequest generateReceiveMessageRequest() {
         return new ReceiveMessageRequest(queueProperties.getQueueUrl())
                 .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(waitTimeInSeconds)
+                .withWaitTimeSeconds(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS)
                 .withVisibilityTimeout(properties.getVisibilityTimeoutForMessagesInSeconds());
     }
 }

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetriever.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetriever.java
@@ -1,7 +1,5 @@
 package com.jashmore.sqs.retriever.prefetch;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import com.google.common.base.Preconditions;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
@@ -13,7 +11,6 @@ import com.jashmore.sqs.retriever.AsyncMessageRetriever;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Optional;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -22,8 +19,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.TimeUnit;
-import javax.validation.constraints.NotNull;
 
 /**
  * Message retriever that allows for the pre-fetching of messages for faster throughput by making sure that there are always messages in a queue locally to be
@@ -124,24 +119,8 @@ public class PrefetchingMessageRetriever implements AsyncMessageRetriever {
     }
 
     @Override
-    public Optional<Message> retrieveMessageNow() throws InterruptedException {
-        return retrieveMessage(0, MILLISECONDS);
-    }
-
-    @Override
     public Message retrieveMessage() throws InterruptedException {
         return internalMessageQueue.take();
-    }
-
-    @Override
-    public Optional<Message> retrieveMessage(final long timeout, @NotNull final TimeUnit timeUnit) throws InterruptedException {
-        Preconditions.checkNotNull(timeUnit, "timeUnit");
-        Preconditions.checkArgument(timeout >= 0, "timeout should be greater than or equal to zero");
-
-        log.trace("Retrieving message");
-        final Message message = internalMessageQueue.poll(timeout, timeUnit);
-
-        return Optional.ofNullable(message);
     }
 
     /**

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetrieverTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetrieverTest.java
@@ -1,8 +1,6 @@
 package com.jashmore.sqs.retriever.individual;
 
 import static com.jashmore.sqs.aws.AwsConstants.MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -21,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -39,153 +36,6 @@ public class IndividualMessageRetrieverTest {
 
     @Mock
     private Future<ReceiveMessageResult> receiveMessageResultFuture;
-
-    @Test
-    public void retrieveMessagesWithTimeoutLessThanOneSecondCallsWithWaitZero() throws ExecutionException, InterruptedException {
-        // arrange
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get()).thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(15, MILLISECONDS);
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(0)
-        );
-    }
-
-    @Test
-    public void retrieveMessagesWithTimeoutWillHaveWaitTimeoutSameAsValueWhenBelow20Seconds() throws ExecutionException, InterruptedException {
-        // arrange
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get()).thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(15, SECONDS);
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(15)
-        );
-    }
-
-    @Test
-    public void retrieveMessagesWithTimeoutWithMillisecondsWithScaleToSecondsForWaitTime() throws ExecutionException, InterruptedException {
-        // arrange
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get()).thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(15400, MILLISECONDS); // 15.4 Seconds
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(15)
-        );
-    }
-
-    @Test
-    public void retrieveMessagesWithTimeoutGreaterThan20SecondsWillCallMultipleTimes() throws ExecutionException, InterruptedException {
-        // arrange
-        when(receiveMessageResultFuture.get())
-                .thenReturn(new ReceiveMessageResult())
-                .thenReturn(new ReceiveMessageResult())
-                .thenReturn(new ReceiveMessageResult())
-                .thenReturn(new ReceiveMessageResult());
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(90, SECONDS);
-
-        // assert
-        assertThat(optionalMessage).isEmpty();
-        verify(amazonSqs, times(4)).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS));
-        verify(amazonSqs, times(1)).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(10));
-    }
-
-    @Test
-    public void retrieveMessagesWithMultipleCallsReturnsWhenMessageReturned() throws ExecutionException, InterruptedException {
-        // arrange
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get())
-                .thenReturn(new ReceiveMessageResult())
-                .thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(90, SECONDS);
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs, times(2)).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS));
-    }
-
-    @Test
-    public void visibilityTimeoutIsPassedIntoAmazonCall() throws ExecutionException, InterruptedException {
-        // arrange
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get()).thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().visibilityTimeoutForMessagesInSeconds(5).build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessage(15, SECONDS);
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(15)
-                .withVisibilityTimeout(5)
-        );
-    }
-
-    @Test
-    public void retrievingMessageNowRequestsWithZeroWaitTime() throws ExecutionException, InterruptedException {
-        final Message message = new Message();
-        when(receiveMessageResultFuture.get()).thenReturn(new ReceiveMessageResult().withMessages(message));
-        when(amazonSqs.receiveMessageAsync(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResultFuture);
-        final IndividualMessageRetriever retriever = new IndividualMessageRetriever(
-                amazonSqs, QUEUE_PROPERTIES, IndividualMessageRetrieverProperties.builder().visibilityTimeoutForMessagesInSeconds(5).build());
-
-        // act
-        final Optional<Message> optionalMessage = retriever.retrieveMessageNow();
-
-        // assert
-        assertThat(optionalMessage).contains(message);
-        verify(amazonSqs).receiveMessageAsync(new ReceiveMessageRequest(QUEUE_URL)
-                .withMaxNumberOfMessages(1)
-                .withWaitTimeSeconds(0)
-                .withVisibilityTimeout(5)
-        );
-    }
 
     @Test
     public void retrievingMessageWithNoTimeoutKeepsCallingUntilRetrieved() throws ExecutionException, InterruptedException {

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverTest.java
@@ -3,6 +3,7 @@ package com.jashmore.sqs.retriever.prefetch;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 import static org.hamcrest.core.Is.isA;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -26,14 +27,14 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
-import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import javax.validation.constraints.NotNull;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 public class PrefetchingMessageRetrieverTest {
@@ -62,28 +63,6 @@ public class PrefetchingMessageRetrieverTest {
     private ExecutorService executorService = Executors.newCachedThreadPool();
 
     @Test
-    public void whenNoMessagesPresentRetrieveMessageIsBlocked() throws InterruptedException {
-        // arrange
-        final CountDownLatch messagesRequested = new CountDownLatch(1);
-        final CountDownLatch testCompletedLatch = new CountDownLatch(1);
-        final PrefetchingMessageRetriever prefetchingMessageRetriever = buildRetriever(testCompletedLatch);
-        when(amazonSqsAsync.receiveMessage(any(ReceiveMessageRequest.class)))
-                .then(waitUntilTestCompleted(messagesRequested, testCompletedLatch));
-        prefetchingMessageRetriever.start();
-        messagesRequested.await(1, SECONDS);
-
-        try {
-            // act
-            final Optional<Message> optionalMessage = prefetchingMessageRetriever.retrieveMessage(50, MILLISECONDS);
-
-            // assert
-            assertThat(optionalMessage).isEmpty();
-        } finally {
-            prefetchingMessageRetriever.stop();
-        }
-    }
-
-    @Test
     public void messageObtainedFromServerCanBeObtained() throws InterruptedException {
         // arrange
         final CountDownLatch testCompletedLatch = new CountDownLatch(1);
@@ -98,10 +77,10 @@ public class PrefetchingMessageRetrieverTest {
 
         // act
         try {
-            final Optional<Message> optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            final Message optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage();
 
             // assert
-            assertThat(optionalFirstMessage).contains(messageFromSqs);
+            assertThat(optionalFirstMessage).isEqualTo(messageFromSqs);
         } finally {
             prefetchingMessageRetriever.stop();
         }
@@ -120,14 +99,34 @@ public class PrefetchingMessageRetrieverTest {
         prefetchingMessageRetriever.start();
 
         // act
-        final Optional<Message> optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
-        requestedSecondMessageLatch.await(1, SECONDS);
+        final Message optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage();
+        assertThat(optionalFirstMessage).isEqualTo(messageFromSqs);
         try {
-            final Optional<Message> secondMessageAttempted = prefetchingMessageRetriever.retrieveMessage(200, TimeUnit.MILLISECONDS);
+            final Future<?> messageWaitingFuture = Executors.newCachedThreadPool().submit(() -> {
+                try {
+                    prefetchingMessageRetriever.retrieveMessage();
+                } catch (InterruptedException interruptedException) {
+                    // should be interrupted
+                }
+            });
 
             // assert
-            assertThat(optionalFirstMessage).contains(messageFromSqs);
-            assertThat(secondMessageAttempted).isEmpty();
+            try {
+                try {
+                    messageWaitingFuture.get(100, MILLISECONDS);
+                } catch (TimeoutException timeoutException) {
+                    messageWaitingFuture.cancel(true);
+                    try {
+                        messageWaitingFuture.get();
+                        fail("Should have cancelled the future");
+                    } catch (CancellationException cancellationException) {
+                        // expected
+                    }
+
+                }
+            } catch (ExecutionException executionException) {
+                throw new RuntimeException(executionException);
+            }
         } finally {
             prefetchingMessageRetriever.stop();
         }
@@ -149,12 +148,12 @@ public class PrefetchingMessageRetrieverTest {
 
         try {
             // act
-            final Optional<Message> optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
-            final Optional<Message> optionalSecondMessage = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            final Message optionalFirstMessage = prefetchingMessageRetriever.retrieveMessage();
+            final Message optionalSecondMessage = prefetchingMessageRetriever.retrieveMessage();
 
             // assert
-            assertThat(optionalFirstMessage).contains(firstMessage);
-            assertThat(optionalSecondMessage).contains(secondMessage);
+            assertThat(optionalFirstMessage).isEqualTo(firstMessage);
+            assertThat(optionalSecondMessage).isEqualTo(secondMessage);
         } finally {
             prefetchingMessageRetriever.stop();
         }
@@ -166,14 +165,15 @@ public class PrefetchingMessageRetrieverTest {
         final CountDownLatch testCompleted = new CountDownLatch(1);
         final CountDownLatch messagesRetrievalLatch = new CountDownLatch(1);
         final CountDownLatch messageRequestedLatch = new CountDownLatch(1);
-        final PrefetchingMessageRetriever prefetchingMessageRetriever = new PrefetchingMessageRetriever(amazonSqsAsync, QUEUE_PROPERTIES, DEFAULT_PREFETCHING_PROPERTIES, executorService) {
+        final PrefetchingMessageRetriever prefetchingMessageRetriever = new PrefetchingMessageRetriever(amazonSqsAsync, QUEUE_PROPERTIES,
+                DEFAULT_PREFETCHING_PROPERTIES, executorService) {
             @Override
-            public Optional<Message> retrieveMessage(final long timeout, @NotNull final TimeUnit timeUnit) throws InterruptedException {
+            public Message retrieveMessage() throws InterruptedException {
                 // Wait until we have sent the request to get some messages from AWS
                 messagesRetrievalLatch.await();
                 // We have requested the message so we can now have AWS return the message
                 messageRequestedLatch.countDown();
-                return super.retrieveMessage(timeout, timeUnit);
+                return super.retrieveMessage();
             }
         };
         final Message message = new Message().withBody("test");
@@ -192,10 +192,10 @@ public class PrefetchingMessageRetrieverTest {
         // act
         prefetchingMessageRetriever.start();
         try {
-            final Optional<Message> optionalMessageRetrieved = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            final Message messageRetrieved = prefetchingMessageRetriever.retrieveMessage();
 
             // assert
-            assertThat(optionalMessageRetrieved).contains(message);
+            assertThat(messageRetrieved).isEqualTo(message);
         } finally {
             prefetchingMessageRetriever.stop();
         }
@@ -264,7 +264,7 @@ public class PrefetchingMessageRetrieverTest {
         assertThat(secondMessageRequestedLatch.getCount()).isEqualTo(1);
 
         try {
-            prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            prefetchingMessageRetriever.retrieveMessage();
             // Now that a message has been consumed the retriever should request for new messages to hit the maxPrefetchedMessages
             secondMessageRequestedLatch.await(1, SECONDS);
         } finally {
@@ -292,7 +292,8 @@ public class PrefetchingMessageRetrieverTest {
         when(amazonSqsAsync.receiveMessageAsync(any(ReceiveMessageRequest.class)))
                 .thenAnswer(invocation -> {
                     messagesReceivedLatch.countDown();
-                    return mockFutureWithGet(new ReceiveMessageResult().withMessages(new Message(), new Message(), new Message(), new Message(), new Message()));
+                    return mockFutureWithGet(new ReceiveMessageResult()
+                            .withMessages(new Message(), new Message(), new Message(), new Message(), new Message()));
                 })
                 .thenAnswer((invocationOnMock) -> {
                     throw new IllegalStateException("This shouldn't get called cause we hit our prefetch limit");
@@ -345,9 +346,9 @@ public class PrefetchingMessageRetrieverTest {
         firstmessagesRequested.await(1, SECONDS);
         Thread.sleep(1000); // Make sure we haven't called the second message
         assertThat(secondmessagesRequested.getCount()).isEqualTo(1L);
-        prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+        prefetchingMessageRetriever.retrieveMessage();
         secondmessagesRequested.await(1, SECONDS);
-        prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+        prefetchingMessageRetriever.retrieveMessage();
         thirdmessagesRequested.await(1, SECONDS);
 
         // assert
@@ -361,8 +362,8 @@ public class PrefetchingMessageRetrieverTest {
     @Test
     public void noExceptionThrownForStoppingWhenAlreadyStopped() {
         // arrange
-        final PrefetchingMessageRetriever prefetchingMessageRetriever = new PrefetchingMessageRetriever(amazonSqsAsync, QUEUE_PROPERTIES, DEFAULT_PREFETCHING_PROPERTIES,
-                executorService);
+        final PrefetchingMessageRetriever prefetchingMessageRetriever = new PrefetchingMessageRetriever(amazonSqsAsync, QUEUE_PROPERTIES,
+                DEFAULT_PREFETCHING_PROPERTIES, executorService);
 
         // act
         prefetchingMessageRetriever.stop();
@@ -456,9 +457,9 @@ public class PrefetchingMessageRetrieverTest {
             prefetchingMessageRetriever.start();
 
             // assert
-            prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            prefetchingMessageRetriever.retrieveMessage();
             verify(amazonSqsAsync, times(1)).receiveMessageAsync(any(ReceiveMessageRequest.class));
-            prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            prefetchingMessageRetriever.retrieveMessage();
             secondPrefetchRequested.await(1, SECONDS);
             verify(amazonSqsAsync, times(2)).receiveMessageAsync(any(ReceiveMessageRequest.class));
         } finally {
@@ -486,10 +487,10 @@ public class PrefetchingMessageRetrieverTest {
         try {
             // act
             prefetchingMessageRetriever.start();
-            final Optional<Message> message = prefetchingMessageRetriever.retrieveMessage(1, SECONDS);
+            final Message message = prefetchingMessageRetriever.retrieveMessage();
 
             // assert
-            assertThat(message).contains(expectedMessage);
+            assertThat(message).isEqualTo(expectedMessage);
         } finally {
             prefetchingMessageRetriever.stop();
         }
@@ -530,7 +531,7 @@ public class PrefetchingMessageRetrieverTest {
         final Future<T> future = mock(Future.class);
         try {
             when(future.get()).thenReturn(result);
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException | ExecutionException exception) {
             // ignore
         }
         return future;


### PR DESCRIPTION
This was removed because ultimately they did not need to be used and they complicated the implementations. The BatchingMessageRetriever method for example ended up being a lot more complicated with it in and therefore removal made more sense.

Fixed a bug in the ConcurrentMessageBroker where thread spinup would be blocked
by message retrieval (this is a problem for the BatchingMessageRetriever implementation
that will be implemented soon).