### PR TITLE
refs #50: Improved documentation for the concurrent message broker properties

### DIFF
--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/CachingConcurrentMessageBrokerProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/CachingConcurrentMessageBrokerProperties.java
@@ -4,6 +4,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
+import net.jcip.annotations.ThreadSafe;
+
 import java.util.concurrent.TimeUnit;
 import javax.validation.constraints.Min;
 
@@ -11,7 +13,10 @@ import javax.validation.constraints.Min;
  * Implementation that will cache the values as the methods to retrieve the values may be costly.
  *
  * <p>For example, an outbound call is needed to get this value and it is costly to do this every time a message has been processed.
+ *
+ * <p>This implementation is thread safe even though it is not required to be due to the thread safety of the {@link LoadingCache}.
  */
+@ThreadSafe
 public class CachingConcurrentMessageBrokerProperties implements ConcurrentMessageBrokerProperties {
     /**
      * Cache key as only a single value is being loaded into the cache.
@@ -21,6 +26,12 @@ public class CachingConcurrentMessageBrokerProperties implements ConcurrentMessa
     private final LoadingCache<Integer, Integer> cachedConcurrencyLevel;
     private final LoadingCache<Integer, Integer> cachedPreferredConcurrencyPollingRateInSeconds;
 
+    /**
+     * Constructor.
+     *
+     * @param cachingTimeoutInMs the amount of time in milliseconds that the values for each property should be cached internally
+     * @param delegateProperties the delegate properties object that should be called when the cache has not been populated yet or has expired
+     */
     public CachingConcurrentMessageBrokerProperties(final int cachingTimeoutInMs,
                                                     final ConcurrentMessageBrokerProperties delegateProperties) {
         this.cachedConcurrencyLevel = CacheBuilder.newBuilder()

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/ConcurrentMessageBrokerProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/ConcurrentMessageBrokerProperties.java
@@ -1,10 +1,52 @@
 package com.jashmore.sqs.broker.concurrent.properties;
 
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker;
+import com.jashmore.sqs.retriever.MessageRetriever;
+
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.validation.constraints.Min;
 
+/**
+ * Properties for dynamically configuring how the {@link ConcurrentMessageBroker} is able to process messages concurrently.
+ *
+ * <p>These properties will be consumed by the {@link ConcurrentMessageBroker} at a high rate (every time a new message is needed) and therefore considerations
+ * should be considered in terms of the performance of this. If obtaining these values are costly, for example calling out to an external system, it is
+ * recommended to cache the values for a period of time so it is not making calls every time a message needed therefore significantly impacting the throughput
+ * of this broker.
+ *
+ * <p>Implementations of these properties do not need to be thread safe because there is only a single coordinating thread that will be consuming this
+ * object.
+ */
+@NotThreadSafe
 public interface ConcurrentMessageBrokerProperties {
     /**
-     * The level of concurrency for processing messages, e.g. the number of threads processing messages.
+     * The level of concurrency for processing messages, e.g. the number of threads that can process messages at the same time. This value can change
+     * dynamically throughout the usage of this broker which can be useful if you want to provide the rate of concurrency behind a feature flag or
+     * configuration in the application.
+     *
+     * <p>The {@link ConcurrentMessageBroker} will maintain the rate of concurrency by checking that the current concurrency rate is aligned with this value.
+     * If there is currently less threads running than this value, more threads will to meet this value. If there are more threads running
+     * than this value, this coordinating thread will block until the amount of concurrent threads has gone below this value or the a certain
+     * amount of time, defined by {@link #getPreferredConcurrencyPollingRateInMilliseconds()}, has passed. In the case that the polling period is reached,
+     * the coordinating thread will do this process again.
+     *
+     * <p>Note that the concurrency rate does not get applied instantly and there are multiple attributing factors for when the rate of concurrency will
+     * actually transition to a new concurrency rate when this value changes, for example:
+     * <ul>
+     *     <li>
+     *         The rate of concurrency may take a while to decrease due to no messages being taken from the queue. Due to internal
+     *         implementation details of the {@link ConcurrentMessageBroker} it will spin up as many threads as the concurrency level where each will wait
+     *         for a message to be retrieved. These threads will not be stopped until a message is taken and processed. Therefore if you have a concurrency
+     *         level of 10, 10 threads will be started all waiting for messages and even though the concurrency rate may decrease to 5, this concurrency rate
+     *         will not decrease until 5 of those 10 threads process a message.  The reason for this is to a) decrease the complexity of the codebase and
+     *         b) we don't know the internal details of the {@link MessageRetriever} and therefore requesting a message but then never using it because
+     *         the thread got interrupted may result in lost messages requiring reprocessing via a re-drive policy.
+     *     </li>
+     *     <li>
+     *         The delay in the concurrency rate change may be due to transitioning from allowing zero threads to a number of threads. In a worst
+     *         case scenario there would be a delay of {@link #getPreferredConcurrencyPollingRateInMilliseconds()} before the rate of concurrency is changed.
+     *     </li>
+     * </ul>
      *
      * @return the the level of concurrency for processing messages
      */
@@ -12,13 +54,17 @@ public interface ConcurrentMessageBrokerProperties {
     Integer getConcurrencyLevel();
 
     /**
-     * The number of milliseconds between checks for the rate of concurrency.
+     * The number of milliseconds that the coordinating thread will sleep when the maximum rate of concurrency has been reached before checking again.
      *
-     * <p>For example, if the concurrency is currently set to 0 (therefore no threads running) it will poll at this rate to see
-     * if the concurrency has increased.
+     * <p>The reason that this property is needed is because during the processing of messages, which could be a significantly long period, the rate
+     * of concurrency may have changed, more specifically increased. To make sure that more threads are spun up as required, the coordinating
+     * thread will block for this period of time and once it is awoken it will check to see if the concurrency level has changed. If it has, more threads
+     * can be spun up to process more messages. However, if the current number of threads is equal to or greater than the desired amount the coordinating
+     * thread will go back to sleep for this period of time or until the number of threads goes below this number.
      *
-     * <p>The higher this number the less CPU intensive the checking is as it is cycling less. The lower this number however the more responsive the application
-     * is to changing concurrency level.
+     * <p>There are performance considerations when determine an appropriate value for this property in that a higher polling period will result in less time
+     * that the coordinating thread is awoken and is therefore less CPU intensive. However, decreasing this polling period makes it more responsive to changes
+     * to the rate of concurrency.
      *
      * @return the number of milliseconds between polls for the concurrency level
      */

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/StaticConcurrentMessageBrokerProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/broker/concurrent/properties/StaticConcurrentMessageBrokerProperties.java
@@ -3,18 +3,26 @@ package com.jashmore.sqs.broker.concurrent.properties;
 import com.google.common.base.Preconditions;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.Value;
+import net.jcip.annotations.ThreadSafe;
 
 import java.util.Optional;
+import javax.validation.constraints.Min;
 
 /**
  * Implementation that stores the value as non-mutable field values and therefore will return the same value on every call.
  *
  * <p>This is useful when you don't need the listener to be dynamic or have the ability to turn off when needed.
+ *
+ * <p>This implementation is thread safe, even though it doesn't need to be, due to it only returning immutable values.
  */
-@Value
+@ToString
+@EqualsAndHashCode
 @Builder
+@ThreadSafe
 public final class StaticConcurrentMessageBrokerProperties implements ConcurrentMessageBrokerProperties {
     private static final Integer DEFAULT_CONCURRENCY_POLLING_IN_MS = 60_000;
 
@@ -24,7 +32,8 @@ public final class StaticConcurrentMessageBrokerProperties implements Concurrent
     @NonNull
     private final Integer preferredConcurrencyPollingRateInMilliseconds;
 
-    public StaticConcurrentMessageBrokerProperties(final Integer concurrencyLevel, final Integer preferredConcurrencyPollingRateInMilliseconds) {
+    public StaticConcurrentMessageBrokerProperties(final Integer concurrencyLevel,
+                                                   final Integer preferredConcurrencyPollingRateInMilliseconds) {
         Preconditions.checkArgument(concurrencyLevel == null || concurrencyLevel >= 0, "concurrencyLevel should be greater than or equal to zero");
         Preconditions.checkArgument(preferredConcurrencyPollingRateInMilliseconds == null || preferredConcurrencyPollingRateInMilliseconds >= 0,
                 "preferredConcurrencyPollingRateInMilliseconds should be greater than or equal to zero");
@@ -33,5 +42,15 @@ public final class StaticConcurrentMessageBrokerProperties implements Concurrent
                 .orElse(0);
         this.preferredConcurrencyPollingRateInMilliseconds = Optional.ofNullable(preferredConcurrencyPollingRateInMilliseconds)
                 .orElse(DEFAULT_CONCURRENCY_POLLING_IN_MS);
+    }
+
+    @Override
+    public @Min(0) Integer getConcurrencyLevel() {
+        return concurrencyLevel;
+    }
+
+    @Override
+    public @Min(0) Integer getPreferredConcurrencyPollingRateInMilliseconds() {
+        return preferredConcurrencyPollingRateInMilliseconds;
     }
 }


### PR DESCRIPTION
This makes it clearer how it works internally for changing the concurrency rate of the broker.