### PR TITLE
refs #92: Message Attribute support

### DIFF
--- a/doc/core-implementations-overview.md
+++ b/doc/core-implementations-overview.md
@@ -72,6 +72,11 @@ with an implementation that allows for a message to be manually acknowledged whe
 signature, the [MessageProcessor](../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java) is not required to
 acknowledge the message after a successful execution. These implementations should be provided by the
 [MessageProcessor](../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java) being used.
+- [MessageAttribute](../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttribute.java): arguments annotated with this
+will attempt to parse the contents of the message attribute into this field. For example, if the argument is a String then the attribute will be cast to a
+string where as if the argument is an integer it will try and parse the string into the number.  This also works with POJOs in that the resolver will
+ attempt to deserialised the message attribute into this POJO shape, e.g. via the Jackson Object Mapper.  This is provided by the
+[MessageAttributeArgumentResolver](../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java).
 - [VisibilityExtender](../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/visibility/VisibilityExtender.java): arguments of this type
 will be injected with an implementation that extends the message visibility of the current message. This is provided by the
 [VisibilityExtenderArgumentResolver](../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/visibility/VisibilityExtenderArgumentResolver.java). 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -19,6 +19,8 @@ more in depth understanding take a look at the JavaDoc for the API.
         1. [How to add a custom ArgumentResolver to a Spring application](how-to-guides/spring/spring-how-to-add-custom-argument-resolver.md): useful for
         integrating custom argument resolution code to be included in a Spring Application. See [How to implement a custom ArgumentResolver](how-to-guides/core/core-how-to-implement-a-custom-argument-resolver.md)
         for how build a new ArgumentResolver from scratch
+        1. [How to provide a custom Object Mapper](how-to-guides/spring/spring-how-to-add-custom-argument-resolver.md): guide for overriding the default
+        `ObjectMapper` that is used to serialise the message body and attributes
         1. [How to add your own queue listener](how-to-guides/spring/spring-how-to-add-own-queue-listener.md): useful for defining your own annotation for
         queue listening without the verbosity of the custom queue listener
         1. [How to write Spring Integration Tests](how-to-guides/spring/spring-how-to-write-integration-tests.md): you actually want to test what you are

--- a/doc/how-to-guides/spring/spring-how-to-provide-a-custom-object-mapper.md
+++ b/doc/how-to-guides/spring/spring-how-to-provide-a-custom-object-mapper.md
@@ -1,0 +1,45 @@
+# Spring - How to provide own ObjectMapper for serialisation/deserialisation
+Currently a Jackson `ObjectMapper` is being used for the serialisation and deserialisation of messages and their attributes. If none is provided
+by the application, the Spring Starter will provide their own to use. This shows steps on providing your own so the default is not used.
+
+### Steps
+
+1. In a `@Configuration` class define a bean of type `ObjectMapper`
+    ```java
+    @Configuration
+    public class MyConfiguration {
+       @Bean
+       public ObjectMapper objectMapper() {
+           return new ObjectMapper();
+       }     
+    }
+    ```
+
+
+## Providing an ObjectMapper without including it in the Spring Context
+One problem with doing this method is that this ObjectMapper will be shared with this library as well as any others that need this, e.g. the HTTP layer
+may be using this ObjectMapper for their own serialisation. Therefore, if you want to provide an `ObjectMapper` that is only used by this library you would
+need to override the individual core [ArgumentResolvers](../../../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/argument/ArgumentResolver.java)
+that are using this `ObjectMapper`, which is the
+[PayloadArgumentResolver](../../../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/payload/PayloadArgumentResolver.java) and
+[MessageAttributeArgumentResolver](../../../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java). 
+
+### Steps
+
+1. In a `@Configuration` class define your own [ArgumentResolverService](../../../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/argument/ArgumentResolverService.java)
+    ```java
+    @Configuration
+    public class MyConfiguration {
+       private static final ObjectMapper MY_OBJECT_MAPPER_FOR_SQS = new ObjectMapper();
+    
+       @Bean
+       public PayloadArgumentResolver payloadArgumentResolver() {
+           return new PayloadArgumentResolver(new JacksonPayloadMapper(MY_OBJECT_MAPPER_FOR_SQS));
+       }   
+    
+       @Bean
+       public MessageAttributeArgumentResolver messageAttributeArgumentResolver() {
+           return new MessageAttributeArgumentResolver(objectMapper);
+       }
+    }
+    ```

--- a/examples/java-dynamic-sqs-listener-core-examples/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
+++ b/examples/java-dynamic-sqs-listener-core-examples/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
@@ -189,7 +189,7 @@ public class ConcurrentBrokerExample {
      */
     private static ArgumentResolverService argumentResolverService(final SqsAsyncClient sqsAsyncClient) {
         final PayloadMapper payloadMapper = new JacksonPayloadMapper(OBJECT_MAPPER);
-        return new CoreArgumentResolverService(payloadMapper, sqsAsyncClient);
+        return new CoreArgumentResolverService(payloadMapper, sqsAsyncClient, OBJECT_MAPPER);
     }
 
     /**

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/CoreArgumentResolverService.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/CoreArgumentResolverService.java
@@ -2,6 +2,8 @@ package com.jashmore.sqs.argument;
 
 import com.google.common.collect.ImmutableSet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jashmore.sqs.argument.attribute.MessageAttributeArgumentResolver;
 import com.jashmore.sqs.argument.messageid.MessageIdArgumentResolver;
 import com.jashmore.sqs.argument.payload.PayloadArgumentResolver;
 import com.jashmore.sqs.argument.payload.mapper.PayloadMapper;
@@ -22,10 +24,12 @@ public class CoreArgumentResolverService implements ArgumentResolverService {
     private final DelegatingArgumentResolverService delegatingArgumentResolverService;
 
     public CoreArgumentResolverService(final PayloadMapper payloadMapper,
-                                       final SqsAsyncClient sqsAsyncClient) {
+                                       final SqsAsyncClient sqsAsyncClient,
+                                       final ObjectMapper objectMapper) {
         final Set<ArgumentResolver<?>> argumentResolvers = ImmutableSet.of(
                 new PayloadArgumentResolver(payloadMapper),
                 new MessageIdArgumentResolver(),
+                new MessageAttributeArgumentResolver(objectMapper),
                 new VisibilityExtenderArgumentResolver(sqsAsyncClient)
         );
         this.delegatingArgumentResolverService = new DelegatingArgumentResolverService(argumentResolvers);

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttribute.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttribute.java
@@ -1,0 +1,28 @@
+package com.jashmore.sqs.argument.attribute;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Populate on of the arguments in a message processing method by taking a value from the message attributes.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface MessageAttribute {
+    /**
+     * The name of the attribute to use.
+     *
+     * @return the attribute name
+     */
+    String value();
+
+    /**
+     * Fail the processing of the message if the message attribute with the provided name does not exist.
+     *
+     * @return whether the message should fail to be processed if the message attribute is missing
+     */
+    boolean required() default false;
+}

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java
@@ -1,0 +1,122 @@
+package com.jashmore.sqs.argument.attribute;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.argument.ArgumentResolutionException;
+import com.jashmore.sqs.argument.ArgumentResolver;
+import com.jashmore.sqs.argument.MethodParameter;
+import com.jashmore.sqs.util.annotation.AnnotationUtils;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentResolver} that is able to handle the extraction of information from the attributes of the SQS message.
+ *
+ * <p>This will attempt to do its best in casting the contents of the message attribute to the type of tha parameter. For example, if the contents of
+ * the message attribute is binary (byte[]) and the parameter is a POJO, it will attempt to serialise using the {@link ObjectMapper#readValue(byte[], Class)}.
+ *
+ * <p>It is the responsibility of the consumer to make sure that the type of the parameter is correct in regards to the content of the message attribute. For
+ * example, this resolver ignores all helper data types after the main, e.g. Number.float data types will have the float ignored.
+ *
+ * <p>This current implementation uses the Jackson {@link ObjectMapper} to perform all of the parsing and there is the potential for a future version of this
+ * library to split this out so that Jackson isn't a required dependency.
+ *
+ * @see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html">SQS Message Attributes</a> for more
+ *     information
+ * @see MessageAttributeValue for more information about these attributes
+ */
+public class MessageAttributeArgumentResolver implements ArgumentResolver<Object> {
+    private final ObjectMapper objectMapper;
+
+    public MessageAttributeArgumentResolver(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean canResolveParameter(final MethodParameter methodParameter) {
+        return AnnotationUtils.findParameterAnnotation(methodParameter, MessageAttribute.class).isPresent();
+    }
+
+    @Override
+    public Object resolveArgumentForParameter(final QueueProperties queueProperties,
+                                              final MethodParameter methodParameter,
+                                              final Message message) throws ArgumentResolutionException {
+        final MessageAttribute annotation = AnnotationUtils.findParameterAnnotation(methodParameter, MessageAttribute.class)
+                .orElseThrow(() -> new ArgumentResolutionException("Parameter passed in does not contain the MessageAttribute annotation when it should"));
+
+        final String attributeName = annotation.value();
+
+        final Optional<MessageAttributeValue> optionalMessageAttributeValue = Optional.ofNullable(message.messageAttributes().get(attributeName));
+
+        if (!optionalMessageAttributeValue.isPresent()) {
+            if (annotation.required()) {
+                throw new ArgumentResolutionException("Required Message Attribute '" + attributeName + "' is missing from message");
+            }
+
+            return null;
+        }
+
+        final MessageAttributeValue messageAttributeValue = optionalMessageAttributeValue.get();
+
+        if (messageAttributeValue.dataType().startsWith(MessageAttributeDataTypes.STRING.getValue())
+                || messageAttributeValue.dataType().startsWith(MessageAttributeDataTypes.NUMBER.getValue())) {
+            return handleStringParameterValue(methodParameter, messageAttributeValue, attributeName);
+        } else if (messageAttributeValue.dataType().startsWith(MessageAttributeDataTypes.BINARY.getValue())) {
+            return handleByteParameterValue(methodParameter, messageAttributeValue);
+        }
+
+        throw new ArgumentResolutionException("Cannot parse message attribute due to unknown data type '" + messageAttributeValue.dataType() + "'");
+    }
+
+    /**
+     * Handle resolving the argument from the string contents of the attribute.
+     *
+     * @param methodParameter       the parameter of the method to resolve
+     * @param messageAttributeValue the value of the message attribute
+     * @param attributeName         the name of the attribute that is being consumed
+     * @return the resolved argument from the attribute
+     */
+    private Object handleStringParameterValue(final MethodParameter methodParameter,
+                                              final MessageAttributeValue messageAttributeValue,
+                                              final String attributeName) {
+        if (methodParameter.getParameter().getType().isAssignableFrom(String.class)) {
+            return messageAttributeValue.stringValue();
+        }
+
+        try {
+            return objectMapper.readValue(messageAttributeValue.stringValue(), methodParameter.getParameter().getType());
+        } catch (final IOException ioException) {
+            throw new ArgumentResolutionException("Error parsing Message Attribute '" + attributeName + "'", ioException);
+        }
+    }
+
+    /**
+     * Handle an attribute that contains the data as bytes.
+     *
+     * @param methodParameter       details about the parameter to parse the message attribute into
+     * @param messageAttributeValue value of the message attribute
+     * @return the argument resolved for this attribute
+     */
+    private Object handleByteParameterValue(final MethodParameter methodParameter,
+                                            final MessageAttributeValue messageAttributeValue) {
+        final byte[] byteArray = messageAttributeValue.binaryValue().asByteArray();
+        final Class<?> parameterClass = methodParameter.getParameter().getType();
+        if (parameterClass == byte[].class) {
+            return byteArray;
+        }
+
+        if (parameterClass.isAssignableFrom(String.class)) {
+            return new String(byteArray, Charset.forName("UTF-8"));
+        }
+
+        try {
+            return objectMapper.readValue(byteArray, parameterClass);
+        } catch (final IOException ioException) {
+            throw new ArgumentResolutionException("Failure to parse binary bytes to '" + parameterClass.getName() + "'", ioException);
+        }
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolver.java
@@ -25,9 +25,8 @@ import java.util.Optional;
  * <p>This current implementation uses the Jackson {@link ObjectMapper} to perform all of the parsing and there is the potential for a future version of this
  * library to split this out so that Jackson isn't a required dependency.
  *
- * @see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html">SQS Message Attributes</a> for more
- *     information
- * @see MessageAttributeValue for more information about these attributes
+ * @see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html">SQS Message Attributes</a>
+ * @see MessageAttributeValue
  */
 public class MessageAttributeArgumentResolver implements ArgumentResolver<Object> {
     private final ObjectMapper objectMapper;

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeDataTypes.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/argument/attribute/MessageAttributeDataTypes.java
@@ -1,0 +1,14 @@
+package com.jashmore.sqs.argument.attribute;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MessageAttributeDataTypes {
+    STRING("String"),
+    NUMBER("Number"),
+    BINARY("Binary");
+
+    private final String value;
+}

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetriever.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetriever.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
@@ -200,9 +201,9 @@ public class BatchingMessageRetriever implements AsyncMessageRetriever {
      * @return the request that will be sent to SQS
      */
     private ReceiveMessageRequest buildReceiveMessageRequest(final int numberOfMessagesToObtain) {
-        final ReceiveMessageRequest.Builder requestBuilder = ReceiveMessageRequest
-                .builder()
+        final ReceiveMessageRequest.Builder requestBuilder = ReceiveMessageRequest.builder()
                 .queueUrl(queueProperties.getQueueUrl())
+                .messageAttributeNames(QueueAttributeName.ALL.toString())
                 .maxNumberOfMessages(numberOfMessagesToObtain)
                 .waitTimeSeconds(RetrieverUtils.safelyGetWaitTimeInSeconds(properties::getMessageWaitTimeInSeconds));
 

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetriever.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetriever.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
@@ -54,6 +55,7 @@ public class IndividualMessageRetriever implements MessageRetriever {
                 .builder()
                 .queueUrl(queueProperties.getQueueUrl())
                 .maxNumberOfMessages(1)
+                .messageAttributeNames(QueueAttributeName.ALL.toString())
                 .waitTimeSeconds(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS)
                 .visibilityTimeout(properties.getVisibilityTimeoutForMessagesInSeconds())
                 .build();

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetriever.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetriever.java
@@ -13,6 +13,7 @@ import com.jashmore.sqs.util.retriever.RetrieverUtils;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
@@ -155,9 +156,9 @@ public class PrefetchingMessageRetriever implements AsyncMessageRetriever {
         final int numberOfMessagesToObtain = Math.min(AwsConstants.MAX_NUMBER_OF_MESSAGES_FROM_SQS, numberOfPrefetchSlotsLeft);
 
         log.debug("Retrieving {} messages asynchronously", numberOfMessagesToObtain);
-        final ReceiveMessageRequest.Builder requestBuilder = ReceiveMessageRequest
-                .builder()
+        final ReceiveMessageRequest.Builder requestBuilder = ReceiveMessageRequest.builder()
                 .queueUrl(queueProperties.getQueueUrl())
+                .messageAttributeNames(QueueAttributeName.ALL.toString())
                 .waitTimeSeconds(RetrieverUtils.safelyGetWaitTimeInSeconds(properties::getMessageWaitTimeInSeconds))
                 .maxNumberOfMessages(numberOfMessagesToObtain);
         final Integer visibilityTimeoutInSeconds = properties.getVisibilityTimeoutForMessagesInSeconds();

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolverTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/argument/attribute/MessageAttributeArgumentResolverTest.java
@@ -1,0 +1,547 @@
+package com.jashmore.sqs.argument.attribute;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jashmore.sqs.argument.ArgumentResolutionException;
+import com.jashmore.sqs.argument.DefaultMethodParameter;
+import com.jashmore.sqs.argument.MethodParameter;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.data.Percentage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@SuppressWarnings( {"unused", "WeakerAccess"})
+public class MessageAttributeArgumentResolverTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private MessageAttributeArgumentResolver messageAttributeArgumentResolver = new MessageAttributeArgumentResolver(new ObjectMapper());
+
+    @Test
+    public void stringMessageAttributesCanBeObtainedFromMessage() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "string", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.STRING.getValue())
+                                .stringValue("my attribute value")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", String.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo("my attribute value");
+    }
+
+    @Test
+    public void unknownDataTypeWillThrowArgumentResolutionException() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "string", MessageAttributeValue.builder()
+                                .dataType("Unknown")
+                                .stringValue("my attribute value")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", String.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+        expectedException.expect(ArgumentResolutionException.class);
+        expectedException.expectMessage("Cannot parse message attribute due to unknown data type 'Unknown'");
+
+        // act
+        messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+    }
+
+    @Test
+    public void missingMessageAttributeWillReturnNullWhenNotRequired() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of())
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", String.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isNull();
+    }
+
+    @Test
+    public void missingMessageAttributeWillThrowArgumentResolutionExceptionWhenRequired() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of())
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeWithRequiredAttribute", String.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+        expectedException.expect(ArgumentResolutionException.class);
+        expectedException.expectMessage("Message Attribute 'string' is missing");
+
+        // act
+        messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+    }
+
+    @Test
+    public void floatCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "float", MessageAttributeValue.builder()
+                                .dataType("Number.float")
+                                .stringValue("1.0")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", float.class, int.class,
+                long.class, byte.class, short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Float value = (Float) messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isCloseTo(1.0f, Percentage.withPercentage(0.1));
+    }
+
+    @Test
+    public void integerCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "int", MessageAttributeValue.builder()
+                                .dataType("Number.int")
+                                .stringValue("1.0")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", float.class, int.class,
+                long.class, byte.class, short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[1])
+                .parameterIndex(1)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(1);
+    }
+
+    @Test
+    public void longCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "long", MessageAttributeValue.builder()
+                                .dataType("Number.long")
+                                .stringValue("1234")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", float.class, int.class,
+                long.class, byte.class, short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[2])
+                .parameterIndex(2)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(1234L);
+    }
+
+    @Test
+    public void byteCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "byte", MessageAttributeValue.builder()
+                                .dataType("Number.byte")
+                                .stringValue("1")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", float.class, int.class,
+                long.class, byte.class, short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[3])
+                .parameterIndex(3)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(new Byte("1"));
+    }
+
+
+    @Test
+    public void shortCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "short", MessageAttributeValue.builder()
+                                .dataType("Number.short")
+                                .stringValue("1")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", float.class, int.class,
+                long.class, byte.class, short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[4])
+                .parameterIndex(4)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo((short)1);
+    }
+
+    @Test
+    public void floatClassCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "float", MessageAttributeValue.builder()
+                                .dataType("Number.float")
+                                .stringValue("1.0")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", Float.class, Integer.class,
+                Long.class, Byte.class, Short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Float value = (Float) messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isCloseTo(1.0f, Percentage.withPercentage(0.1));
+    }
+
+    @Test
+    public void integerClassCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "int", MessageAttributeValue.builder()
+                                .dataType("Number.int")
+                                .stringValue("1.0")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", Float.class, Integer.class,
+                Long.class, Byte.class, Short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[1])
+                .parameterIndex(1)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(1);
+    }
+
+    @Test
+    public void longClassCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "long", MessageAttributeValue.builder()
+                                .dataType("Number.long")
+                                .stringValue("1234")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", Float.class, Integer.class,
+                Long.class, Byte.class, Short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[2])
+                .parameterIndex(2)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(1234L);
+    }
+
+    @Test
+    public void byteClassCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "byte", MessageAttributeValue.builder()
+                                .dataType("Number.byte")
+                                .stringValue("12")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", Float.class, Integer.class,
+                Long.class, Byte.class, Short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[3])
+                .parameterIndex(3)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(new Byte("12"));
+    }
+
+    @Test
+    public void shortClassCanBeCreatedFromNumberMessageAttributes() throws Exception {
+        // arrange
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "short", MessageAttributeValue.builder()
+                                .dataType("Number.short")
+                                .stringValue("12")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consumeNumbers", Float.class, Integer.class,
+                Long.class, Byte.class, Short.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[4])
+                .parameterIndex(4)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(new Short("12"));
+    }
+
+    @Test
+    public void pojoCanBeDeserialisedFromMessageAttribute() throws Exception {
+        final MyPojo pojo = MyPojo.builder().name("name").build();
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "pojo", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.STRING.getValue())
+                                .stringValue(new ObjectMapper().writeValueAsString(pojo))
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", MyPojo.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object value = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(value).isEqualTo(pojo);
+    }
+
+    @Test
+    public void attributeThatCannotBeProperlyParsedThrowsArgumentResolutionException() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "pojo", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.STRING.getValue())
+                                .stringValue("Expected Test Exception")
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", MyPojo.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+        expectedException.expect(ArgumentResolutionException.class);
+        expectedException.expectMessage("Error parsing Message Attribute 'pojo'");
+
+        // act
+        messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+    }
+
+    @Test
+    public void canExtractBytesFromBinaryMessageAttribute() throws Exception {
+        final byte[] binaryBytes = "some string".getBytes();
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "bytes", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.BINARY.getValue())
+                                .binaryValue(SdkBytes.fromByteArray(binaryBytes))
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", byte[].class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object object = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(object).isEqualTo(binaryBytes);
+    }
+
+    @Test
+    public void canParseStringFromBinaryMessageAttribute() throws Exception {
+        final String expectedString = "some string";
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "string", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.BINARY.getValue())
+                                .binaryValue(SdkBytes.fromByteArray(expectedString.getBytes()))
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", String.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object object = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(object).isEqualTo(expectedString);
+    }
+
+    @Test
+    public void canParseObjectFromBinaryMessageAttribute() throws Exception {
+        final MyPojo myPojo = MyPojo.builder().name("name").build();
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "pojo", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.BINARY.getValue())
+                                .binaryValue(SdkBytes.fromByteArray(new ObjectMapper().writeValueAsBytes(myPojo)))
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", MyPojo.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+
+        // act
+        final Object object = messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+
+        // assert
+        assertThat(object).isEqualTo(myPojo);
+    }
+
+    @Test
+    public void failureParseObjectFromBinaryMessageAttributeWillThrowArgumentResolutionException() throws Exception {
+        final Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(
+                        "pojo", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.BINARY.getValue())
+                                .binaryValue(SdkBytes.fromByteArray("My String".getBytes()))
+                                .build()
+                ))
+                .build();
+        final Method method = MessageAttributeArgumentResolverTest.class.getMethod("consume", MyPojo.class);
+        final MethodParameter methodParameter = DefaultMethodParameter.builder()
+                .method(method)
+                .parameter(method.getParameters()[0])
+                .parameterIndex(0)
+                .build();
+        expectedException.expect(ArgumentResolutionException.class);
+        expectedException.expectMessage("Failure to parse binary bytes to '" + MyPojo.class.getName() + "'");
+
+        // act
+        messageAttributeArgumentResolver.resolveArgumentForParameter(null, methodParameter, message);
+    }
+
+    public void consume(@MessageAttribute("string") final String messageAttribute) {
+    }
+
+    public void consumeWithRequiredAttribute(@MessageAttribute(value = "string", required = true) final String messageAttribute) {
+    }
+
+    public void consumeNumbers(@MessageAttribute("float") float f,
+                               @MessageAttribute("int") int i,
+                               @MessageAttribute("long") long l,
+                               @MessageAttribute("byte") byte b,
+                               @MessageAttribute("short") short s) {
+    }
+
+    public void consumeNumbers(@MessageAttribute("float") Float f,
+                               @MessageAttribute("int") Integer i,
+                               @MessageAttribute("long") Long l,
+                               @MessageAttribute("byte") Byte b,
+                               @MessageAttribute("short") Short s) {
+    }
+
+    public void consume(@MessageAttribute("pojo") final MyPojo pojo) {
+
+    }
+
+    public void consume(@MessageAttribute("bytes") final byte[] b) {
+
+    }
+
+    @Value
+    @Builder
+    public static class MyPojo {
+        private final String name;
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetrieverTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/retriever/individual/IndividualMessageRetrieverTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
@@ -58,6 +59,7 @@ public class IndividualMessageRetrieverTest {
         verify(sqsAsyncClient, times(5)).receiveMessage(ReceiveMessageRequest.builder()
                 .queueUrl(QUEUE_URL)
                 .maxNumberOfMessages(1)
+                .messageAttributeNames(QueueAttributeName.ALL.toString())
                 .waitTimeSeconds(MAX_SQS_RECEIVE_WAIT_TIME_IN_SECONDS)
                 .visibilityTimeout(5)
                 .build()

--- a/java-dynamic-sqs-listener-core/src/test/java/it/com/jashmore/sqs/argument/MessageAttributeIntegrationTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/it/com/jashmore/sqs/argument/MessageAttributeIntegrationTest.java
@@ -1,0 +1,125 @@
+package it.com.jashmore.sqs.argument;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.argument.ArgumentResolverService;
+import com.jashmore.sqs.argument.CoreArgumentResolverService;
+import com.jashmore.sqs.argument.attribute.MessageAttribute;
+import com.jashmore.sqs.argument.attribute.MessageAttributeDataTypes;
+import com.jashmore.sqs.argument.payload.mapper.JacksonPayloadMapper;
+import com.jashmore.sqs.argument.payload.mapper.PayloadMapper;
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker;
+import com.jashmore.sqs.broker.concurrent.StaticConcurrentMessageBrokerProperties;
+import com.jashmore.sqs.container.SimpleMessageListenerContainer;
+import com.jashmore.sqs.processor.DefaultMessageProcessor;
+import com.jashmore.sqs.processor.MessageProcessor;
+import com.jashmore.sqs.resolver.MessageResolver;
+import com.jashmore.sqs.resolver.blocking.BlockingMessageResolver;
+import com.jashmore.sqs.resolver.individual.IndividualMessageResolver;
+import com.jashmore.sqs.retriever.MessageRetriever;
+import com.jashmore.sqs.retriever.individual.IndividualMessageRetriever;
+import com.jashmore.sqs.retriever.individual.IndividualMessageRetrieverProperties;
+import com.jashmore.sqs.test.LocalSqsRule;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Slf4j
+public class MessageAttributeIntegrationTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final PayloadMapper PAYLOAD_MAPPER = new JacksonPayloadMapper(OBJECT_MAPPER);
+
+    @Rule
+    public LocalSqsRule localSqsRule = new LocalSqsRule();
+
+    private String queueUrl;
+    private QueueProperties queueProperties;
+    private ArgumentResolverService argumentResolverService;
+
+    @Before
+    public void setUp() {
+        queueUrl = localSqsRule.createRandomQueue();
+        queueProperties = QueueProperties.builder().queueUrl(queueUrl).build();
+        argumentResolverService = new CoreArgumentResolverService(PAYLOAD_MAPPER, localSqsRule.getLocalAmazonSqsAsync(), OBJECT_MAPPER);
+    }
+
+    @Test
+    public void messageAttributesCanBeConsumedInMessageProcessingMethods() throws Exception {
+        // arrange
+        final SqsAsyncClient sqsAsyncClient = localSqsRule.getLocalAmazonSqsAsync();
+        final MessageRetriever messageRetriever = new IndividualMessageRetriever(
+                sqsAsyncClient,
+                queueProperties,
+                IndividualMessageRetrieverProperties.builder()
+                        .visibilityTimeoutForMessagesInSeconds(30)
+                        .build()
+        );
+        final CountDownLatch messageProcessedLatch = new CountDownLatch(1);
+        final AtomicReference<String> messageAttributeReference = new AtomicReference<>();
+        final MessageConsumer messageConsumer = new MessageConsumer(messageProcessedLatch, messageAttributeReference);
+        final MessageResolver messageResolver = new BlockingMessageResolver(new IndividualMessageResolver(queueProperties, sqsAsyncClient));
+        final MessageProcessor messageProcessor = new DefaultMessageProcessor(
+                argumentResolverService,
+                queueProperties,
+                messageResolver,
+                MessageConsumer.class.getMethod("consume", String.class),
+                messageConsumer
+        );
+        final ConcurrentMessageBroker messageBroker = new ConcurrentMessageBroker(
+                messageRetriever,
+                messageProcessor,
+                StaticConcurrentMessageBrokerProperties.builder()
+                        .concurrencyLevel(1)
+                        .build()
+        );
+        final SimpleMessageListenerContainer simpleMessageListenerContainer = new SimpleMessageListenerContainer(
+                messageRetriever, messageBroker, messageResolver
+        );
+        simpleMessageListenerContainer.start();
+
+        // act
+        sqsAsyncClient.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody("test")
+                .messageAttributes(ImmutableMap.of(
+                        "key",
+                        MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.STRING.getValue())
+                                .stringValue("expected value")
+                                .build()
+                ))
+                .build())
+                .get(2, SECONDS);
+
+        assertThat(messageProcessedLatch.await(5, SECONDS)).isTrue();
+        simpleMessageListenerContainer.stop();
+
+        // assert
+        assertThat(messageAttributeReference).hasValue("expected value");
+    }
+
+    @AllArgsConstructor
+    public static class MessageConsumer {
+        private final CountDownLatch latch;
+        private final AtomicReference<String> valueAtomicReference;
+
+        public void consume(@MessageAttribute("key") final String value) {
+            log.info("Message processed with attribute: {}", value);
+            latch.countDown();
+            valueAtomicReference.set(value);
+        }
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/it/com/jashmore/sqs/listener/concurrent/ConcurrentMessageBrokerIntegrationTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/it/com/jashmore/sqs/listener/concurrent/ConcurrentMessageBrokerIntegrationTest.java
@@ -50,7 +50,7 @@ public class ConcurrentMessageBrokerIntegrationTest {
     public void setUp() {
         queueUrl = localSqsRule.createRandomQueue();
         queueProperties = QueueProperties.builder().queueUrl(queueUrl).build();
-        argumentResolverService = new CoreArgumentResolverService(PAYLOAD_MAPPER, localSqsRule.getLocalAmazonSqsAsync());
+        argumentResolverService = new CoreArgumentResolverService(PAYLOAD_MAPPER, localSqsRule.getLocalAmazonSqsAsync(), OBJECT_MAPPER);
     }
 
     @Test(timeout = 30_000)

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-starter/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-starter/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
@@ -8,7 +8,6 @@ import com.jashmore.sqs.argument.attribute.MessageAttributeArgumentResolver;
 import com.jashmore.sqs.argument.messageid.MessageIdArgumentResolver;
 import com.jashmore.sqs.argument.payload.PayloadArgumentResolver;
 import com.jashmore.sqs.argument.payload.mapper.JacksonPayloadMapper;
-import com.jashmore.sqs.argument.payload.mapper.PayloadMapper;
 import com.jashmore.sqs.argument.visibility.VisibilityExtenderArgumentResolver;
 import com.jashmore.sqs.container.MessageListenerContainer;
 import com.jashmore.sqs.spring.DefaultQueueContainerService;
@@ -117,14 +116,6 @@ public class QueueListenerConfiguration {
                 return new VisibilityExtenderArgumentResolver(sqsAsyncClient);
             }
 
-            /**
-             * The default {@link MessageAttributeArgumentResolver} that will be able to deserialise message attributes using the Jackson {@link ObjectMapper}.
-             *
-             * <p>If a custom {@link ObjectMapper} needs to be supplied for the parsing of the  or the default {@link PayloadMapper} implementation is not
-             * up to scratch, the consumer can supply their own {@link PayloadMapper} bean and this one will not be used.
-             *
-             * @return the payload mapper for message payload deserialisation
-             */
             @Bean
             @ConditionalOnMissingBean(MessageAttributeArgumentResolver.class)
             public MessageAttributeArgumentResolver messageAttributeArgumentResolver(final ObjectMapper objectMapper) {

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-starter/src/test/java/it/com/jashmore/sqs/argument/MessageAttributeSpringIntegrationTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-starter/src/test/java/it/com/jashmore/sqs/argument/MessageAttributeSpringIntegrationTest.java
@@ -1,0 +1,93 @@
+package it.com.jashmore.sqs.argument;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.jashmore.sqs.argument.attribute.MessageAttribute;
+import com.jashmore.sqs.argument.attribute.MessageAttributeDataTypes;
+import com.jashmore.sqs.spring.container.basic.QueueListener;
+import com.jashmore.sqs.test.LocalSqsRule;
+import com.jashmore.sqs.test.PurgeQueuesRule;
+import com.jashmore.sqs.util.LocalSqsAsyncClient;
+import com.jashmore.sqs.util.SqsQueuesConfig;
+import it.com.jashmore.example.Application;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.junit4.SpringRunner;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@SuppressWarnings("unused")
+@Slf4j
+@SpringBootTest(classes = {Application.class, MessageAttributeSpringIntegrationTest.TestConfig.class}, webEnvironment = RANDOM_PORT)
+@RunWith(SpringRunner.class)
+public class MessageAttributeSpringIntegrationTest {
+    private static final String QUEUE_NAME = "MessageAttributeSpringIntegrationTest";
+    private static final CountDownLatch COUNT_DOWN_LATCH = new CountDownLatch(1);
+    private static final AtomicReference<String> messageAttributeReference = new AtomicReference<>();
+
+    @ClassRule
+    public static final LocalSqsRule LOCAL_SQS_RULE = new LocalSqsRule(ImmutableList.of(
+            SqsQueuesConfig.QueueConfig.builder().queueName(QUEUE_NAME).build()
+    ));
+
+    @Rule
+    public final PurgeQueuesRule purgeQueuesRule = new PurgeQueuesRule(LOCAL_SQS_RULE.getLocalAmazonSqsAsync());
+
+    @Autowired
+    private LocalSqsAsyncClient localSqsAsyncClient;
+
+    @Configuration
+    public static class TestConfig {
+        @Bean
+        public LocalSqsAsyncClient localSqsAsyncClient() {
+            return LOCAL_SQS_RULE.getLocalAmazonSqsAsync();
+        }
+
+        @Service
+        public static class MessageListener {
+            @QueueListener(value = QUEUE_NAME)
+            public void listenToMessage(@MessageAttribute("key") final String value) {
+                log.info("Obtained message: {}", value);
+                messageAttributeReference.set(value);
+                COUNT_DOWN_LATCH.countDown();
+            }
+        }
+    }
+
+    @Test
+    public void allMessagesAreProcessedByListeners() throws Exception {
+        // arrange
+        localSqsAsyncClient.sendMessageToLocalQueue(QUEUE_NAME, SendMessageRequest.builder()
+                .messageBody("message")
+                .messageAttributes(ImmutableMap.of(
+                        "key", MessageAttributeValue.builder()
+                                .dataType(MessageAttributeDataTypes.STRING.getValue())
+                                .stringValue("value")
+                                .build()
+                ))
+                .build())
+                .get(5, TimeUnit.SECONDS);
+
+        // act
+        COUNT_DOWN_LATCH.await(20, TimeUnit.SECONDS);
+
+        // assert
+        assertThat(messageAttributeReference).hasValue("value");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <excludes>
                                 <exclude>com/jashmore/sqs/examples/**/*</exclude>
                                 <exclude>com/jashmore/sqs/aws/*</exclude>


### PR DESCRIPTION
We can now use the @MessageAttribute annotation in the message processing methods to consume message attributes in the message.