### PR TITLE
refs #112: Made the batch size for the batching queue listeners instead of using concurrency

### DIFF
--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/resolver/batching/StaticBatchingMessageResolverProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/resolver/batching/StaticBatchingMessageResolverProperties.java
@@ -1,6 +1,7 @@
 package com.jashmore.sqs.resolver.batching;
 
 import lombok.Builder;
+import lombok.Value;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Positive;
@@ -8,6 +9,7 @@ import javax.validation.constraints.Positive;
 /**
  * Static implementation that will contain constant size and time limit for the buffer.
  */
+@Value
 @Builder(toBuilder = true)
 public class StaticBatchingMessageResolverProperties implements BatchingMessageResolverProperties {
     private final long bufferingTimeInMs;

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
@@ -29,9 +29,13 @@ public interface BatchingMessageRetrieverProperties {
      * <p>Note that this trigger size may not be reached due to the the waiting time going higher than {@link #getMessageRetrievalPollingPeriodInMs()}, in
      * this case it will just request as many messages as threads requesting messages.
      *
+     * <p>This number should be smaller than the maximum number of messages that can be downloaded from AWS as it doesn't make much sense to have a batch size
+     * greater than this value.
+     *
      * @return the number of threads to be requesting messages for the retrieval of messages background thread to be triggered
      */
     @Positive
+    @Max(AwsConstants.MAX_NUMBER_OF_MESSAGES_FROM_SQS)
     int getNumberOfThreadsWaitingTrigger();
 
     /**

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/QueueListener.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/QueueListener.java
@@ -5,6 +5,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.aws.AwsConstants;
 import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker;
 import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties;
 import com.jashmore.sqs.container.MessageListenerContainer;
@@ -82,6 +83,31 @@ public @interface QueueListener {
      * @see ConcurrentMessageBrokerProperties#getConcurrencyLevel() for more details and constraints
      */
     String concurrencyLevelString() default "";
+
+    /**
+     * The total number of threads requesting messages that will result in the the background thread to actually request the messages.
+     *
+     * <p>This number should be positive but smaller than {@link AwsConstants#MAX_NUMBER_OF_MESSAGES_FROM_SQS} as it does not make sense to have a batch size
+     * greater than what AWS can provide.
+     *
+     * @return the total number of threads requesting messages for trigger a batch of messages to be retrieved
+     * @see BatchingMessageRetrieverProperties#getNumberOfThreadsWaitingTrigger() for more details about this parameter
+     */
+    int batchSize() default 5;
+
+    /**
+     * The total number of threads requesting messages that will result in the the background thread to actually request the messages.
+     *
+     * <p>This number should be positive but smaller than {@link AwsConstants#MAX_NUMBER_OF_MESSAGES_FROM_SQS} as it does not make sense to have a batch size
+     * greater than what AWS can provide.
+     *
+     * <p>This can be used when you need to load the value from Spring properties for example
+     * <pre>batchSizeString = "${my.profile.property}"</pre> instead of having it hardcoded in {@link #batchSize()}.
+     *
+     * @return the total number of threads requesting messages for trigger a batch of messages to be retrieved
+     * @see BatchingMessageRetrieverProperties#getNumberOfThreadsWaitingTrigger() for more details about this parameter
+     */
+    String batchSizeString() default "";
 
     /**
      * The maximum period of time that the {@link BatchingMessageRetriever} will wait for all threads to be ready before retrieving messages.

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/batching/BatchingQueueListener.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/batching/BatchingQueueListener.java
@@ -4,6 +4,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.aws.AwsConstants;
 import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker;
 import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties;
 import com.jashmore.sqs.container.MessageListenerContainer;
@@ -86,14 +87,35 @@ public @interface BatchingQueueListener {
     String concurrencyLevelString() default "";
 
     /**
+     * The total number of threads requesting messages that will result in the the background thread to actually request the messages.
+     *
+     * <p>This number should be positive but smaller than {@link AwsConstants#MAX_NUMBER_OF_MESSAGES_FROM_SQS} as it does not make sense to have a batch size
+     * greater than what AWS can provide.
+     *
+     * @return the total number of threads requesting messages for trigger a batch of messages to be retrieved
+     * @see BatchingMessageRetrieverProperties#getNumberOfThreadsWaitingTrigger() for more details about this parameter
+     */
+    int batchSize() default 5;
+
+    /**
+     * The total number of threads requesting messages that will result in the the background thread to actually request the messages.
+     *
+     * <p>This number should be positive but smaller than {@link AwsConstants#MAX_NUMBER_OF_MESSAGES_FROM_SQS} as it does not make sense to have a batch size
+     * greater than what AWS can provide.
+     *
+     * <p>This can be used when you need to load the value from Spring properties for example
+     * <pre>batchSizeString = "${my.profile.property}"</pre> instead of having it hardcoded in {@link #batchSize()}.
+     *
+     * @return the total number of threads requesting messages for trigger a batch of messages to be retrieved
+     * @see BatchingMessageRetrieverProperties#getNumberOfThreadsWaitingTrigger() for more details about this parameter
+     */
+    String batchSizeString() default "";
+
+    /**
      * The maximum period of time that the {@link BatchingMessageRetriever} will wait for all threads to be ready before retrieving messages.
      *
-     * <p>This tries to reduce the number of times that requests for messages are made to SQS by waiting for all of the threads to be requiring messages
-     * before requesting for messages from SQS. If one or more of the threads processing messages does not start requesting messages by this period's
-     * timeout the current threads waiting for messages will have messages requested for them
-     *
      * @return the period in ms that threads will wait for messages to be requested from SQS
-     * @see BatchingMessageRetrieverProperties#getMessageRetrievalPollingPeriodInMs() for more details
+     * @see BatchingMessageRetrieverProperties#getMessageRetrievalPollingPeriodInMs() for more details about this parameter
      */
     long maxPeriodBetweenBatchesInMs() default 2000L;
 

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/com/jashmore/sqs/spring/container/basic/QueueListenerWrapperTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/com/jashmore/sqs/spring/container/basic/QueueListenerWrapperTest.java
@@ -165,18 +165,18 @@ public class QueueListenerWrapperTest {
     @Test
     public void batchingMessageRetrieverPropertiesBuiltFromAnnotationValues() throws Exception {
         // arrange
-        final Method method = QueueListenerWrapperTest.class.getMethod("myMethodWithParameters");
+        final Method method = QueueListenerWrapperTest.class.getMethod("methodWithFields");
         final QueueListener annotation = method.getAnnotation(QueueListener.class);
 
         // act
         final BatchingMessageRetrieverProperties properties
-                = queueListenerWrapper.batchingMessageRetrieverProperties(annotation, 2);
+                = queueListenerWrapper.batchingMessageRetrieverProperties(annotation);
 
         // assert
         assertThat(properties).isEqualTo(StaticBatchingMessageRetrieverProperties.builder()
                 .visibilityTimeoutInSeconds(300)
-                .messageRetrievalPollingPeriodInMs(60L)
-                .numberOfThreadsWaitingTrigger(2)
+                .messageRetrievalPollingPeriodInMs(40L)
+                .numberOfThreadsWaitingTrigger(10)
                 .build()
         );
     }
@@ -186,18 +186,19 @@ public class QueueListenerWrapperTest {
         // arrange
         final Method method = QueueListenerWrapperTest.class.getMethod("methodWithFieldsUsingEnvironmentProperties");
         final QueueListener annotation = method.getAnnotation(QueueListener.class);
+        when(environment.resolvePlaceholders("${prop.batchSize}")).thenReturn("8");
         when(environment.resolvePlaceholders("${prop.period}")).thenReturn("30");
         when(environment.resolvePlaceholders("${prop.visibility}")).thenReturn("40");
 
         // act
         final BatchingMessageRetrieverProperties properties
-                = queueListenerWrapper.batchingMessageRetrieverProperties(annotation, 2);
+                = queueListenerWrapper.batchingMessageRetrieverProperties(annotation);
 
         // assert
         assertThat(properties).isEqualTo(StaticBatchingMessageRetrieverProperties.builder()
                 .visibilityTimeoutInSeconds(40)
                 .messageRetrievalPollingPeriodInMs(30L)
-                .numberOfThreadsWaitingTrigger(2)
+                .numberOfThreadsWaitingTrigger(8)
                 .build()
         );
     }
@@ -212,14 +213,14 @@ public class QueueListenerWrapperTest {
 
     }
 
-    @QueueListener(value = "test2", concurrencyLevelString = "${prop.concurrency}",
+    @QueueListener(value = "test2", concurrencyLevelString = "${prop.concurrency}", batchSizeString = "${prop.batchSize}",
             messageVisibilityTimeoutInSecondsString = "${prop.visibility}", maxPeriodBetweenBatchesInMsString = "${prop.period}")
     public void methodWithFieldsUsingEnvironmentProperties() {
 
     }
 
-    @QueueListener(value = "test", concurrencyLevel = 6, messageVisibilityTimeoutInSeconds = 300, maxPeriodBetweenBatchesInMs = 60)
-    public void myMethodWithParameters() {
+    @QueueListener(value = "test2", concurrencyLevel = 20, batchSize = 10, messageVisibilityTimeoutInSeconds = 300, maxPeriodBetweenBatchesInMs = 40)
+    public void methodWithFields() {
 
     }
 }


### PR DESCRIPTION
This is because they are independent properties that should be configurable. For example you want a concurrency rate of 30 but only request messages in batches of 10. E.g. 25 messages are currently being processed and we want to wait for 5 to be completed before requesting more messages to process.