### PR TITLE
refs #151: Makes sure message broker executor service is shutdown.

### DIFF
--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainer.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainer.java
@@ -161,18 +161,30 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
             final Queue<Message> extraMessages = new LinkedList<>();
 
             final BlockingRunnable shutdownMessageRetriever = startupMessageRetriever(messageRetriever, extraMessages::addAll);
-
+            log.info("Container '{}' is beginning to process messages", identifier);
             processMessagesFromRetriever(messageBroker, messageRetriever, messageProcessor, messageResolver,
                     messageBrokerExecutorService, messageProcessingExecutorService);
             log.info("Container '{}' is being shutdown", identifier);
+            log.debug("Container '{}' is shutting down MessageRetriever", identifier);
             shutdownMessageRetriever.run();
-            processExtraMessages(messageBroker, messageProcessor, messageResolver, messageBrokerExecutorService,
-                    messageProcessingExecutorService, extraMessages);
+            log.debug("Container '{}' has stopped the MessageRetriever", identifier);
+            if (!extraMessages.isEmpty() && shouldProcessAnyExtraRetrievedMessagesOnShutdown()) {
+                log.info("Container '{}' is processing {} extra messages before shutdown", identifier, extraMessages.size());
+                processExtraMessages(messageBroker, messageProcessor, messageResolver, messageBrokerExecutorService,
+                        messageProcessingExecutorService, extraMessages);
+            }
+            log.debug("Container '{}' is shutting down MessageProcessor threads", identifier);
             shutdownMessageProcessingThreads(messageProcessingExecutorService);
+            log.debug("Container '{}' has shutdown the MessageProcessor threads", identifier);
+            log.debug("Container '{}' is shutting down MessageResolver", identifier);
             shutdownMessageResolver.run();
+            log.debug("Container '{}' has shutdown the MessageResolver", identifier);
+            log.debug("Container '{}' is shutting down MessageBroker", identifier);
+            shutdownMessageBroker(messageBrokerExecutorService);
+            log.debug("Container '{}' has shutdown the MessageBroker", identifier);
             log.info("Container '{}' has stopped", identifier);
         } catch (final InterruptedException interruptedException) {
-            log.error("Container '{}' was interrupted during the shutdown process. Doing a forceful shutdown that may eventually complete", identifier);
+            log.error("Container '{}' was interrupted during the shutdown process.", identifier);
         } catch (RuntimeException runtimeException) {
             log.error("Unexpected error trying to start/stop the container", runtimeException);
         }
@@ -199,7 +211,6 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
                                               final MessageResolver messageResolver,
                                               final ExecutorService brokerExecutorService,
                                               final ExecutorService messageProcessingExecutorService) throws InterruptedException {
-        log.info("Container '{}' is beginning to process messages", identifier);
         try {
             runUntilInterruption(brokerExecutorService, () -> messageBroker.processMessages(
                     messageProcessingExecutorService,
@@ -227,18 +238,15 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
                                       final ExecutorService messageBrokerExecutorService,
                                       final ExecutorService executorService,
                                       final Queue<Message> messages) throws InterruptedException {
-        if (!messages.isEmpty() && shouldProcessAnyExtraRetrievedMessagesOnShutdown()) {
-            log.debug("Container '{}' is processing {} extra messages before shutdown", identifier, messages.size());
-            try {
-                runUntilInterruption(messageBrokerExecutorService, () -> messageBroker.processMessages(
-                        executorService,
-                        () -> !messages.isEmpty(),
-                        () -> CompletableFuture.completedFuture(messages.poll()),
-                        message -> messageProcessor.processMessage(message, () -> messageResolver.resolveMessage(message))
-                ));
-            } catch (final ExecutionException executionException) {
-                log.error("Exception thrown processing extra messages", executionException.getCause());
-            }
+        try {
+            runUntilInterruption(messageBrokerExecutorService, () -> messageBroker.processMessages(
+                    executorService,
+                    () -> !messages.isEmpty(),
+                    () -> CompletableFuture.completedFuture(messages.poll()),
+                    message -> messageProcessor.processMessage(message, () -> messageResolver.resolveMessage(message))
+            ));
+        } catch (final ExecutionException executionException) {
+            log.error("Exception thrown processing extra messages", executionException.getCause());
         }
     }
 
@@ -281,15 +289,35 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
      * @throws InterruptedException if the thread was interrupted during this process
      */
     private void shutdownMessageProcessingThreads(final ExecutorService executorService) throws InterruptedException {
-        log.debug("Container '{}' is waiting for all message processing threads to finish...", identifier);
         if (shouldInterruptMessageProcessingThreadsOnShutdown()) {
+            log.debug("Container '{}' is interrupting and then waiting for all message processing threads to finish", identifier);
             executorService.shutdownNow();
-            log.debug("Container '{}' interrupted the message processing threads", identifier);
         } else {
+            log.debug("Container '{}' is waiting for all message processing threads to finish", identifier);
             executorService.shutdown();
         }
 
-        executorService.awaitTermination(getMessageProcessingShutdownTimeoutInSeconds(), SECONDS);
+        final int shutdownTimeoutInSeconds = getMessageProcessingShutdownTimeoutInSeconds();
+        final boolean messageProcessingTerminated = executorService.awaitTermination(shutdownTimeoutInSeconds, SECONDS);
+        if (!messageProcessingTerminated) {
+            log.error("Container '{}' did not shutdown MessageProcessor threads within {} seconds", identifier, shutdownTimeoutInSeconds);
+        }
+    }
+
+    /**
+     * Stop the message broker thread and wait for the configured amount of time to complete.
+     *
+     * @param executorService the executor service for the message broker
+     * @throws InterruptedException if the thread was interrupted while waiting for the service to stop
+     */
+    private void shutdownMessageBroker(final ExecutorService executorService) throws InterruptedException {
+        executorService.shutdownNow();
+
+        final int shutdownTimeoutInSeconds = getMessageBrokerShutdownTimeoutInSeconds();
+        final boolean terminationResult = executorService.awaitTermination(shutdownTimeoutInSeconds, SECONDS);
+        if (!terminationResult) {
+            log.error("Container '{}' did not shutdown MessageBroker within {} seconds", getIdentifier(), shutdownTimeoutInSeconds);
+        }
     }
 
     /**
@@ -309,14 +337,12 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
         CompletableFuture.supplyAsync(messageRetriever::run, executorService)
                 .thenAccept(extraMessagesConsumer);
         return () -> {
-            log.info("Shutting down MessageRetriever");
             executorService.shutdownNow();
 
-            final boolean retrieverShutdown;
             final int retrieverShutdownTimeoutInSeconds = getMessageRetrieverShutdownTimeoutInSeconds();
-            retrieverShutdown = executorService.awaitTermination(retrieverShutdownTimeoutInSeconds, SECONDS);
+            final boolean  retrieverShutdown = executorService.awaitTermination(retrieverShutdownTimeoutInSeconds, SECONDS);
             if (!retrieverShutdown) {
-                log.error("MessageRetriever did not shutdown within {} seconds", retrieverShutdownTimeoutInSeconds);
+                log.error("Container '{}' did not shutdown MessageRetriever within {} seconds", getIdentifier(), retrieverShutdownTimeoutInSeconds);
             }
         };
     }
@@ -332,13 +358,12 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
         final ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory(getIdentifier() + "-message-resolver"));
         CompletableFuture.runAsync(messageResolver::run, executorService);
         return () -> {
-            log.info("Shutting down MessageResolver");
             executorService.shutdownNow();
 
             final long messageResolverShutdownTimeInSeconds = getMessageResolverShutdownTimeoutInSeconds();
             final boolean messageResolverShutdown = executorService.awaitTermination(getMessageResolverShutdownTimeoutInSeconds(), SECONDS);
             if (!messageResolverShutdown) {
-                log.error("MessageResolver did not shutdown within {} seconds", messageResolverShutdownTimeInSeconds);
+                log.error("Container '{}' did not shutdown MessageResolver within {} seconds", getIdentifier(), messageResolverShutdownTimeInSeconds);
             }
         };
     }
@@ -366,6 +391,19 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
     }
 
     /**
+     * Get the amount of time in seconds that we should wait for the {@link MessageBroker} to shutdown when requested.
+     *
+     * @return the amount of time in seconds to wait for shutdown
+     */
+    private int getMessageBrokerShutdownTimeoutInSeconds() {
+        return PropertyUtils.safelyGetPositiveOrZeroIntegerValue(
+                "messageBrokerShutdownTimeoutInSeconds",
+                properties::getMessageBrokerShutdownTimeoutInSeconds,
+                DEFAULT_SHUTDOWN_TIME_IN_SECONDS
+        );
+    }
+
+    /**
      * Get the amount of time in seconds that we should wait for the {@link MessageRetriever} to shutdown when requested.
      *
      * @return the amount of time in seconds to wait for shutdown
@@ -385,7 +423,7 @@ public class CoreMessageListenerContainer implements MessageListenerContainer {
      */
     private int getMessageResolverShutdownTimeoutInSeconds() {
         return PropertyUtils.safelyGetPositiveOrZeroIntegerValue(
-                "messageRetrieverShutdownTimeoutInSeconds",
+                "messageResolverShutdownTimeoutInSeconds",
                 properties::getMessageResolverShutdownTimeoutInSeconds,
                 DEFAULT_SHUTDOWN_TIME_IN_SECONDS
         );

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
@@ -33,7 +33,22 @@ public interface CoreMessageListenerContainerProperties {
     Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown();
 
     /**
-     * Gets the amount of time that the broker should wait for the {@link MessageRetriever} to shutdown when the broker is being shutdown.
+     * Gets the amount of time that the container should wait for the {@link com.jashmore.sqs.broker.MessageBroker} to shutdown when the broker is
+     * being shutdown.
+     *
+     * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
+     *
+     * @return the number of seconds to wait for the message retriever to shutdown
+     */
+    @Nullable
+    @PositiveOrZero
+    default Integer getMessageBrokerShutdownTimeoutInSeconds() {
+        // Added to not cause an API breaking change
+        return null;
+    }
+
+    /**
+     * Gets the amount of time that the container should wait for the {@link MessageRetriever} to shutdown when the broker is being shutdown.
      *
      * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
      *
@@ -44,7 +59,7 @@ public interface CoreMessageListenerContainerProperties {
     Integer getMessageRetrieverShutdownTimeoutInSeconds();
 
     /**
-     * The number of seconds that the broker should wait for the message processing threads to finish when a shutdown is initiated.
+     * The number of seconds that the container should wait for the message processing threads to finish when a shutdown is initiated.
      *
      * <p>When {@link #shouldProcessAnyExtraRetrievedMessagesOnShutdown()} is true and there are extra messages to be processed, this field will try and
      * put as many messages onto threads to be processed before this limit is hit. If this time limit is reached some messages may not have been processed.
@@ -58,7 +73,7 @@ public interface CoreMessageListenerContainerProperties {
     Integer getMessageProcessingShutdownTimeoutInSeconds();
 
     /**
-     * Gets the amount of time that the broker should wait for the {@link MessageResolver} to shutdown when the broker is being shutdown.
+     * Gets the amount of time that the container should wait for the {@link MessageResolver} to shutdown when the broker is being shutdown.
      *
      * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
      *

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
@@ -9,12 +9,13 @@ import javax.validation.constraints.PositiveOrZero;
 @Value
 @Builder(toBuilder = true)
 public class StaticCoreMessageListenerContainerProperties implements CoreMessageListenerContainerProperties {
-    private final String messageProcessingThreadNameFormat;
-    private final Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown;
-    private final Boolean shouldInterruptThreadsProcessingMessagesOnShutdown;
-    private final Integer messageProcessingShutdownTimeoutInSeconds;
-    private final Integer messageRetrieverShutdownTimeoutInSeconds;
-    private final Integer messageResolverShutdownTimeoutInSeconds;
+    String messageProcessingThreadNameFormat;
+    Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown;
+    Boolean shouldInterruptThreadsProcessingMessagesOnShutdown;
+    Integer messageProcessingShutdownTimeoutInSeconds;
+    Integer messageRetrieverShutdownTimeoutInSeconds;
+    Integer messageResolverShutdownTimeoutInSeconds;
+    Integer messageBrokerShutdownTimeoutInSeconds;
 
     @Nullable
     @Override
@@ -26,6 +27,12 @@ public class StaticCoreMessageListenerContainerProperties implements CoreMessage
     @Override
     public Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown() {
         return shouldProcessAnyExtraRetrievedMessagesOnShutdown;
+    }
+
+    @Nullable
+    @Override
+    public @PositiveOrZero Integer getMessageBrokerShutdownTimeoutInSeconds() {
+        return messageBrokerShutdownTimeoutInSeconds;
     }
 
     @Nullable

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
@@ -14,6 +14,7 @@ import com.jashmore.sqs.broker.MessageBroker;
 import com.jashmore.sqs.processor.MessageProcessor;
 import com.jashmore.sqs.resolver.MessageResolver;
 import com.jashmore.sqs.retriever.MessageRetriever;
+import com.jashmore.sqs.util.concurrent.CompletableFutureUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,12 +36,8 @@ import java.util.function.Supplier;
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class CoreMessageListenerContainerTest {
-    private static final CompletableFuture<Message> STUB_MESSAGE_BROKER_DONE;
-
-    static {
-        STUB_MESSAGE_BROKER_DONE = new CompletableFuture<>();
-        STUB_MESSAGE_BROKER_DONE.completeExceptionally(new RuntimeException("Expected Messages Done"));
-    }
+    private static final CompletableFuture<Message> STUB_MESSAGE_BROKER_DONE
+            = CompletableFutureUtils.completedExceptionally(new RuntimeException("Expected Messages Done"));
 
     private static final StaticCoreMessageListenerContainerProperties DEFAULT_PROPERTIES = StaticCoreMessageListenerContainerProperties.builder()
             .shouldInterruptThreadsProcessingMessagesOnShutdown(true)
@@ -49,6 +46,7 @@ class CoreMessageListenerContainerTest {
             .messageProcessingShutdownTimeoutInSeconds(5)
             .messageResolverShutdownTimeoutInSeconds(5)
             .messageRetrieverShutdownTimeoutInSeconds(5)
+            .messageBrokerShutdownTimeoutInSeconds(5)
             .build();
 
     @Mock
@@ -256,6 +254,25 @@ class CoreMessageListenerContainerTest {
     }
 
     @Test
+    void allMessageListenerThreadsWillBeShutdownWhenContainerShutdown() {
+        // arrange
+        when(messageRetriever.retrieveMessage())
+                .thenReturn(STUB_MESSAGE_BROKER_DONE);
+        when(messageRetriever.run()).thenReturn(ImmutableList.of());
+        final StaticCoreMessageListenerContainerProperties properties = DEFAULT_PROPERTIES.toBuilder()
+                .shouldProcessAnyExtraRetrievedMessagesOnShutdown(true)
+                .build();
+        final CoreMessageListenerContainer container = buildContainer(
+                "id", new StubMessageBroker(), messageResolver, messageProcessor, messageRetriever, properties);
+
+        // act
+        container.runContainer();
+
+        // assert
+        assertThat(Thread.getAllStackTraces().keySet()).noneMatch(thread -> thread.getName().startsWith("id"));
+    }
+
+    @Test
     void willInterruptMessagesProcessingDuringShutdownWhenPropertySetToTrue() {
         // arrange
         final CountDownLatch messageProcessing = new CountDownLatch(1);
@@ -286,7 +303,7 @@ class CoreMessageListenerContainerTest {
         container.runContainer();
 
         // assert
-        assertThat(wasThreadInterrupted).isTrue();
+        assertThat(wasThreadInterrupted.get()).isTrue();
     }
 
     @Test
@@ -346,7 +363,7 @@ class CoreMessageListenerContainerTest {
         container.runContainer();
 
         // assert
-        assertThat(messageRetrieverInterrupted).isTrue();
+        assertThat(messageRetrieverInterrupted.get()).isTrue();
     }
 
     @Test
@@ -371,7 +388,7 @@ class CoreMessageListenerContainerTest {
         container.runContainer();
 
         // assert
-        assertThat(messageResolverInterrupted).isTrue();
+        assertThat(messageResolverInterrupted.get()).isTrue();
     }
 
     @Test
@@ -407,7 +424,7 @@ class CoreMessageListenerContainerTest {
         container.runContainer();
 
         // assert
-        assertThat(messageResolverInterrupted).isTrue();
+        assertThat(messageResolverInterrupted.get()).isTrue();
     }
 
     @Test

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
@@ -254,7 +254,7 @@ class CoreMessageListenerContainerTest {
     }
 
     @Test
-    void allMessageListenerThreadsWillBeShutdownWhenContainerShutdown() {
+    void allMessageListenerThreadsWillBeShutdownWhenContainerShutdown() throws InterruptedException {
         // arrange
         when(messageRetriever.retrieveMessage())
                 .thenReturn(STUB_MESSAGE_BROKER_DONE);
@@ -263,13 +263,14 @@ class CoreMessageListenerContainerTest {
                 .shouldProcessAnyExtraRetrievedMessagesOnShutdown(true)
                 .build();
         final CoreMessageListenerContainer container = buildContainer(
-                "id", new StubMessageBroker(), messageResolver, messageProcessor, messageRetriever, properties);
+                "my-specific-container-id", new StubMessageBroker(), messageResolver, messageProcessor, messageRetriever, properties);
 
         // act
         container.runContainer();
+        Thread.sleep(1000); // let's just wait a little bit just to be sure that the thread is gone
 
         // assert
-        assertThat(Thread.getAllStackTraces().keySet()).noneMatch(thread -> thread.getName().startsWith("id"));
+        assertThat(Thread.getAllStackTraces().keySet()).noneMatch(thread -> thread.getName().startsWith("my-specific-container-id"));
     }
 
     @Test


### PR DESCRIPTION
Also cleans up the logs for the CoreMessageListenerContainer to be
more consistent, as well as providing debug logs for better debugging
for each stage of the shutdown.