### PR TITLE
#164 message processing decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ As the application grows, it may be beneficial to allow for versioning of the sc
 different versions of the schema. To allow for this the [spring-cloud-schema-registry-extension](extensions/spring-cloud-schema-registry-extension) was written
 to support this functionality. See the [README.md](extensions/spring-cloud-schema-registry-extension/README.md) for this extension for more details.
 
+### Wrapping the Message Listener execution using a MessageProcessingDecorator
+If you require to wrap the message listeners with some custom logic, like metrics, logging or other functionality, you can do this using a
+[MessageProcessingDecorator](java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java). This provides callback
+functions that will be executed at certain stages of the message processing lifecycle.  For more information on use cases and implementations, take a
+look at [Core - How to create a message processing decorator](doc/how-to-guides/core/core-how-to-create-a-message-processing-decorator.md).
+
 ### Comparing Libraries
 If you want to see the difference between this library and others like the
 [Spring Cloud AWS Messaging](https://github.com/spring-cloud/spring-cloud-aws/tree/master/spring-cloud-aws-messaging) and

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ public class MyMessageListener {
 }
 ```
 
-This will use any user configured `SqsAsyncClient` in the application context for connecting to the queue, otherwise if none is defined, a default
-is provided that will look for AWS credentials/region from multiple areas, like the environment variables. See
+This will use any user configured `SqsAsyncClient` in the application context for connecting to the queue, otherwise if none are defined, a default
+will be provided that will look for AWS credentials/region from multiple areas, like the environment variables. See
 [How to connect to AWS SQS Queues](./doc/how-to-guides/how-to-connect-to-aws-sqs-queue.md) for information about connecting to an actual queue in SQS.
 
 ## Core Infrastructure
@@ -119,7 +119,7 @@ before requesting messages for threads waiting for another message.
 ### Setting up a queue listener that prefetches messages
 When the amount of messages for a service is extremely high, prefetching messages may be a way to optimise the throughput of the application. The
 [@PrefetchingQueueListener](./java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingQueueListener.java)
-annotation can be used to pretech messages in a background thread while messages are currently being processed.  The usage is something like this:
+annotation can be used to pre-fetch messages in a background thread while processing the existing messages.  The usage is something like this:
 
 ```java
 @Service
@@ -131,11 +131,11 @@ public class MyMessageListener {
 }
 ```
 
-In this example, if the amount of prefetched messages is below the desired amount of prefetched messages it will try and get as many messages as possible
+In this example, if the amount of prefetched messages is below the desired amount of prefetched messages it will try to get as many messages as possible
 maximum.
 
 *Note: because of the limit of the number of messages that can be obtained from SQS at once (10), having the maxPrefetchedMessages more than
-10 above the desiredMinPrefetchedMessages will not provide much value as once it has prefetched more than the desired prefeteched messages it will
+10 above the desiredMinPrefetchedMessages will not provide much value as once it has prefetched more than the desired prefetched messages it will
 not prefetch anymore.*
 
 ### Adding a custom argument resolver
@@ -197,8 +197,8 @@ For a more extensive guide for doing this, take a look at
 [Spring - How to add a custom Argument Resolver](doc/how-to-guides/spring/spring-how-to-add-custom-argument-resolver.md).
 
 ### Building a custom queue listener annotation
-The core Queue Listener annotations may not provide the exact use case necessary for the application and they also do not provide any dynamic functionality and
-therefore it would be useful to provide your own annotation. See
+The core Queue Listener annotations may not provide the exact use case necessary for the application and therefore it can be useful to provide your
+own annotation. See
 [Spring - How to add a custom queue wrapper](doc/how-to-guides/spring/spring-how-to-add-own-queue-listener.md) for a guide to doing this.
 
 ### Testing locally an example Spring Boot app with the Spring Starter 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -15,11 +15,15 @@ more in depth understanding take a look at the JavaDoc for the [java-dynamic-sqs
         extending the visibility of a message in the case of long processing so it does not get put back on the queue while processing
         1. [How to manually acknowledge message](how-to-guides/core/core-how-to-mark-message-as-successfully-processed.md): useful for when you want to mark the
         message as successfully processed before the method has finished executing
+        1. [How to create a MessageProcessingDecorator](how-to-guides/core/core-how-to-create-a-message-processing-decorator.md): guide for writing your own
+        decorator to wrap a message listener's processing of a message
     1. [How to Connect to an AWS SQS Queue](how-to-guides/how-to-connect-to-aws-sqs-queue.md): necessary for actually using this framework in live environments
     1. Spring How To Guides
         1. [How to add a custom ArgumentResolver to a Spring application](how-to-guides/spring/spring-how-to-add-custom-argument-resolver.md): useful for
         integrating custom argument resolution code to be included in a Spring Application. See [How to implement a custom ArgumentResolver](how-to-guides/core/core-how-to-implement-a-custom-argument-resolver.md)
         for how build a new ArgumentResolver from scratch
+        1. [ How to add custom MessageProcessingDecorators](how-to-guides/spring/spring-how-to-add-custom-message-processing-decorators.md): guide on how
+        to autowire custom `MessageProcessingDecorators` into your Spring Queue Listeners.
         1. [How to provide a custom Object Mapper](how-to-guides/spring/spring-how-to-add-custom-argument-resolver.md): guide for overriding the default
         `ObjectMapper` that is used to serialise the message body and attributes
         1. [How to add your own queue listener](how-to-guides/spring/spring-how-to-add-own-queue-listener.md): useful for defining your own annotation for the

--- a/doc/how-to-guides/core/core-how-to-create-a-message-processing-decorator.md
+++ b/doc/how-to-guides/core/core-how-to-create-a-message-processing-decorator.md
@@ -1,0 +1,181 @@
+# Core - How to create a message processing decorator
+The [MessageProcessingDecorator](../../../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java) is used
+to wrap the processing of the messages with extra functionality like logging, metrics, etc.  This guide provides some examples of message decorators and
+then how to use them.
+
+## Synchronous vs Asynchronous
+The one bit of complexity with these decorators is handling message listeners that are either synchronous or asynchronous in nature. Therefore, care should
+be taken when using ThreadLocals or other thread based variables as it could cause unintended outcomes.
+
+### Synchronous Message Listeners
+Synchronous message listeners are when the message listener does not return a `CompletableFuture` and therefore runs all the processing in the current thread.
+In this scenario, the message processing callbacks will be run on the same thread. For example, given this example implementation you can see which
+callbacks will be run on which thread:
+
+```java
+public class ExampleMessageProcessingDecorator implements MessageProcessingDecorator {
+
+    @Override
+    public void onPreMessageProcessing(MessageProcessingContext context, Message message) {
+        // message-listener-thread
+    }
+
+    @Override
+    public  void onMessageProcessingFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+        // message-listener-thread
+    }
+
+    @Override
+    public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+        // message-listener-thread
+    }
+
+    @Override
+    public void onMessageProcessingThreadComplete(MessageProcessingContext context, Message message) {
+        // message-listener-thread
+    }
+
+    @Override
+    public void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
+        // non message-listener-thread
+    }
+
+    @Override
+    public void onMessageResolvedFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+        // non message-listener-thread
+    }
+}
+```
+
+### Asynchronous Message Listener
+Asynchronous message listeners are when the message listener returns a `CompletableFuture` and will mark the message has successfully being processed when
+the future is resolved.  In this scenario, the message processing callbacks will not be run on the same thread as the message listener. For example, given
+this implementation you can see which callbacks will be run on which thread:
+
+```java
+public class ExampleMessageProcessingDecorator implements MessageProcessingDecorator {
+
+    @Override
+    public void onPreMessageProcessing(MessageProcessingContext context, Message message) {
+        // message-listener-thread
+    }
+
+    @Override
+    public  void onMessageProcessingFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+        // not guaranteed to be the message-listener-thread
+        // It will be whatever thread the message listener is running the message processing on
+    }
+
+    @Override
+    public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+        // not guaranteed to be the message-listener-thread
+        // It will be whatever thread the message listener is running the message processing on
+    }
+
+    @Override
+    public void onMessageProcessingThreadComplete(MessageProcessingContext context, Message message) {
+        // message-listener-thread
+    }
+
+    @Override
+    public void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
+        // non message-listener-thread
+    }
+
+    @Override
+    public void onMessageResolvedFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+        // non message-listener-thread
+    }
+}
+```
+
+## Adding the MessageProcessingDecorators to the message processing
+There is a [DecoratingMessageProcessor](../../../java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/DecoratingMessageProcessor.java) which
+wraps a delegate `MessageProcessor` with this decorating logic. You can then use this `MessageProcessor` instead of the delegate in your
+`MessageListenerContainer`.
+
+```java
+List<MessageProcessingDecorator> decorators = ...;
+
+return new DecoratingMessageProcessor(
+        "message-listener-identifier",
+        queueProperties,
+        decorators,
+        new CoreMessageProcessor(
+                argumentResolverService,
+                queueProperties,
+                sqsAsyncClient,
+                messageListenerMethod,
+                messageListener
+        )
+);
+```
+
+For integrating when running in a Spring application, take a look at
+[Spring - How to add custom MessageProcessingDecorators](../spring/spring-how-to-add-custom-message-processing-decorators.md).
+
+## Examples
+
+### Logging
+You want all logs in the message listener to contain the message ID of the message.
+
+```java
+public class MdcMessageProcessingDecorator implements MessageProcessingDecorator {
+
+    @Override
+    public void onPreMessageProcessing(MessageProcessingContext context, Message message) {
+        MDC.put("message.id", message.messageId());
+    }
+
+    @Override
+    public void onMessageProcessingThreadComplete(MessageProcessingContext context, Message message) {
+        MDC.remove("message.id");
+    }
+}
+```
+
+### Metrics
+You want to monitor the number of messages attempting to be processed as well as the number that were successfully processed.
+
+```java
+public class MetricsMessageProcessingDecorator implements MessageProcessingDecorator {
+    private final MyMetricsService metrics;
+
+    public MetricsMessageProcessingDecorator(final MyMetricsService metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void onPreMessageProcessing(MessageProcessingContext context, Message message) {
+        metrics.trackMessageBeingProessed();
+    }
+
+    @Override
+    public void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
+        metrics.messageSuccessfullyProcessed();
+    }
+}
+```
+
+## Sharing information between callbacks
+As we cannot guarantee that all callbacks will be run on the same thread, instead of using a `ThreadLocal` you can use the
+[MessageProcessingContext](../../../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingContext.java) to set
+attributes in there for your future usage.
+
+```java
+@Slf4J
+public class MdcMessageProcessingDecorator implements MessageProcessingDecorator {
+
+    @Override
+    public void onPreMessageProcessing(MessageProcessingContext context, Message message) {
+        long startTime = System.currentTimeMillis();
+        context.setAttribute("startTime", startTime);
+    }
+
+    @Override
+    public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+        long endTime = System.currentTimeMillis();
+        log.info("Message processed in {}ms", endTime - (long) context.getAttribute("startTime"));
+    }
+}
+```

--- a/doc/how-to-guides/spring/spring-how-to-add-custom-message-processing-decorators.md
+++ b/doc/how-to-guides/spring/spring-how-to-add-custom-message-processing-decorators.md
@@ -1,0 +1,13 @@
+# Spring - How to add Custom MessageProcessingDecorators
+If you have a custom [MessageProcessingDecorator](../../../java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java)
+that you want to apply to all the default message listeners you can just add it as a spring bean and it should be auto configured.
+
+```java
+@Configuration
+public class MyConfiguration {
+    @Bean
+    public MessageProcessingDecorator myDecorator() {
+        return new MyMessageProcessingDecorator();
+    }
+}
+```

--- a/examples/core-examples/pom.xml
+++ b/examples/core-examples/pom.xml
@@ -34,8 +34,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.elasticmq</groupId>
-            <artifactId>elasticmq-rest-sqs_2.12</artifactId>
+            <groupId>com.jashmore</groupId>
+            <artifactId>elasticmq-sqs-client</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/core-examples/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
+++ b/examples/core-examples/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
@@ -1,9 +1,7 @@
 package com.jashmore.sqs.examples;
 
-import static com.jashmore.sqs.aws.AwsConstants.MAX_NUMBER_OF_MESSAGES_IN_BATCH;
 import static java.util.stream.Collectors.toSet;
 
-import akka.http.scaladsl.Http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jashmore.sqs.QueueProperties;
@@ -19,7 +17,9 @@ import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker;
 import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties;
 import com.jashmore.sqs.container.CoreMessageListenerContainer;
 import com.jashmore.sqs.container.MessageListenerContainer;
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient;
 import com.jashmore.sqs.processor.CoreMessageProcessor;
+import com.jashmore.sqs.processor.DecoratingMessageProcessor;
 import com.jashmore.sqs.processor.MessageProcessor;
 import com.jashmore.sqs.resolver.MessageResolver;
 import com.jashmore.sqs.resolver.batching.BatchingMessageResolver;
@@ -27,21 +27,17 @@ import com.jashmore.sqs.resolver.batching.StaticBatchingMessageResolverPropertie
 import com.jashmore.sqs.retriever.MessageRetriever;
 import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetriever;
 import com.jashmore.sqs.retriever.prefetch.StaticPrefetchingMessageRetrieverProperties;
+import com.jashmore.sqs.util.CreateRandomQueueResponse;
+import com.jashmore.sqs.util.LocalSqsAsyncClient;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticmq.rest.sqs.SQSRestServer;
-import org.elasticmq.rest.sqs.SQSRestServerBuilder;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -67,8 +63,6 @@ public class ConcurrentBrokerExample {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private static final String QUEUE_NAME = "my_queue";
-
     /**
      * Example that will continue to place messages on the message queue with a message listener consuming them.
      *
@@ -77,48 +71,25 @@ public class ConcurrentBrokerExample {
      */
     public static void main(final String[] args) throws Exception {
         // Sets up the SQS that will be used
-        final SqsAsyncClient sqsAsyncClient = startElasticMqServer();
-        final String queueUrl = sqsAsyncClient.createQueue((request) -> request.queueName(QUEUE_NAME).build()).get().queueUrl();
+        final LocalSqsAsyncClient sqsAsyncClient = new ElasticMqSqsAsyncClient();
+        final CreateRandomQueueResponse response = sqsAsyncClient.createRandomQueue().get();
         final QueueProperties queueProperties = QueueProperties
                 .builder()
-                .queueUrl(queueUrl)
+                .queueUrl(response.queueUrl())
                 .build();
 
+        final String identifier = "core-example-container";
         final MessageListenerContainer messageListenerContainer = new CoreMessageListenerContainer(
-                "core-example-container",
+                identifier,
                 ConcurrentBrokerExample::buildBroker,
                 () -> buildMessageRetriever(queueProperties, sqsAsyncClient),
-                () -> buildMessageProcessor(queueProperties, sqsAsyncClient),
+                () -> buildMessageProcessor(identifier, queueProperties, sqsAsyncClient),
                 () -> buildMessageResolver(queueProperties, sqsAsyncClient)
         );
         messageListenerContainer.start();
 
         log.info("Starting producing");
-        Executors.newSingleThreadExecutor().submit(new Producer(sqsAsyncClient, queueUrl))
-                .get();
-    }
-
-    /**
-     * Runs a local Elastic MQ server that will act like the SQS queue for local testing.
-     *
-     * <p>This is useful as it means the users of this example don't need to worry about setting up any queue system them self.
-     *
-     * @return amazon sqs client for connecting the local queue
-     */
-    private static SqsAsyncClient startElasticMqServer() throws URISyntaxException {
-        log.info("Starting Local ElasticMQ SQS Server");
-        final SQSRestServer sqsRestServer = SQSRestServerBuilder
-                .withInterface("localhost")
-                .withDynamicPort()
-                .start();
-
-        final Http.ServerBinding serverBinding = sqsRestServer.waitUntilStarted();
-
-        return SqsAsyncClient.builder()
-                .region(Region.of("elasticmq"))
-                .endpointOverride(new URI("http://localhost:" + serverBinding.localAddress().getPort()))
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKeyId", "secretAccessKey")))
-                .build();
+        Executors.newSingleThreadExecutor().submit(new Producer(sqsAsyncClient, response.queueUrl())).get();
     }
 
     private static MessageBroker buildBroker() {
@@ -145,7 +116,9 @@ public class ConcurrentBrokerExample {
         );
     }
 
-    private static MessageProcessor buildMessageProcessor(final QueueProperties queueProperties,
+    @SuppressWarnings("SameParameterValue")
+    private static MessageProcessor buildMessageProcessor(final String identifier,
+                                                          final QueueProperties queueProperties,
                                                           final SqsAsyncClient sqsAsyncClient) {
         final MessageConsumer messageConsumer = new MessageConsumer();
         final Method messageReceivedMethod;
@@ -155,12 +128,17 @@ public class ConcurrentBrokerExample {
             throw new RuntimeException(exception);
         }
 
-        return new CoreMessageProcessor(
-                argumentResolverService(),
+        return new DecoratingMessageProcessor(
+                identifier,
                 queueProperties,
-                sqsAsyncClient,
-                messageReceivedMethod,
-                messageConsumer
+                Collections.emptyList(),
+                new CoreMessageProcessor(
+                        argumentResolverService(),
+                        queueProperties,
+                        sqsAsyncClient,
+                        messageReceivedMethod,
+                        messageConsumer
+                )
         );
     }
 
@@ -168,7 +146,7 @@ public class ConcurrentBrokerExample {
                                                         final SqsAsyncClient sqsAsyncClient) {
         return new BatchingMessageResolver(queueProperties, sqsAsyncClient,
                 StaticBatchingMessageResolverProperties.builder()
-                        .bufferingSizeLimit(MAX_NUMBER_OF_MESSAGES_IN_BATCH)
+                        .bufferingSizeLimit(1)
                         .bufferingTimeInMs(5000)
                         .build());
 
@@ -230,7 +208,7 @@ public class ConcurrentBrokerExample {
                             .collect(toSet()));
                     log.info("Put 10 messages onto queue");
                     async.sendMessageBatch(batchRequestBuilder.build());
-                    Thread.sleep(500);
+                    Thread.sleep(2000);
                 } catch (final InterruptedException interruptedException) {
                     log.info("Producer Thread has been interrupted");
                     shouldStop = true;
@@ -256,7 +234,7 @@ public class ConcurrentBrokerExample {
          * <p>This is useful when the concurrency is dynamically changing we can see that we are in fact properly processing them with the correct
          * concurrency level.
          */
-        private static AtomicInteger concurrentMessagesBeingProcessed = new AtomicInteger(0);
+        private static final AtomicInteger concurrentMessagesBeingProcessed = new AtomicInteger(0);
 
         /**
          * Random number generator for calculating the random time that a message will take to be processed.

--- a/examples/core-examples/src/main/resources/logback.xml
+++ b/examples/core-examples/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg %yellow(%mdc) %n</pattern>
         </encoder>
     </appender>
 
@@ -13,7 +13,7 @@
 
     <logger name="com.jashmore" level="INFO" />
 
-    <root level="info">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/QueueProperties.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/QueueProperties.java
@@ -14,5 +14,5 @@ public class QueueProperties {
     /**
      * The URL of the queue that can be used by the Amazon clients to add, remove messages etc.
      */
-    private final String queueUrl;
+    String queueUrl;
 }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingContext.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingContext.java
@@ -1,0 +1,61 @@
+package com.jashmore.sqs.decorator;
+
+import com.jashmore.sqs.QueueProperties;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Value
+@Builder
+public class MessageProcessingContext {
+    /**
+     * The unique identifier for this message listener.
+     *
+     * <p>For example: my-message-consumer or any other custom identifier.
+     */
+    @NonNull
+    String listenerIdentifier;
+
+    /**
+     * The details about the queue that this message processor is running against.
+     */
+    @NonNull
+    QueueProperties queueProperties;
+
+    /**
+     * Processing attributes that you can use to share objects through each stage of the processing.
+     *
+     * <p>For example, you may want to store the start time for when the message has begun to be processing
+     * for usage by a later decorator method to determine the time to process the message.
+     */
+    @NonNull
+    Map<String, Object> attributes;
+
+    /**
+     * Helper method to get an attribute with the given key.
+     *
+     * @param key the key of the attribute
+     * @return the value of the attribute or null if it does not exist
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T> T getAttribute(final String key) {
+        return (T) attributes.get(key);
+    }
+
+    /**
+     * Helper method to set an attribute with the given key.
+     *
+     * @param key   the key of the attribute
+     * @param value the value to set for the attribute
+     * @return this object for further chaining if necessary
+     */
+    public MessageProcessingContext setAttribute(@Nonnull final String key, final Object value) {
+        attributes.put(key, value);
+        return this;
+    }
+}

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
@@ -2,28 +2,19 @@ package com.jashmore.sqs.decorator;
 
 import com.jashmore.sqs.processor.MessageProcessor;
 import com.jashmore.sqs.processor.argument.Acknowledge;
-import com.jashmore.sqs.resolver.MessageResolver;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Used to decorate the thread that will be used to process the given message.
  *
  * <p>This can be used to add extra information to the thread, such as Tracing, metrics, logging, etc.
- *
- * <p>For context on which each types of events that can be decorated, please take a look at the following key words:
- * <ul>
- *     <li><b>supply</b>: this represents the {@link MessageProcessor} handing (supplying) the message to the message listener to process the
- *     message. Once the message listener function returns the supply task is deemed completed.
- *     <li><b>processing</b>: this represents the actual logic the performs the message processing. If this process completes successfully it indicates that
- *     the message listener succeeded and it should attempt to be resolved, however if it is completed unsuccessfully the message will not be resolved.
- *     <li><b>resolve</b>: resolving a message represents the attempt to mark the message as completed successfully, e.g. calling to
- *     {@link MessageResolver#resolveMessage(Message)}.
- * </ul>
  */
 @SuppressWarnings("unused")
+@ThreadSafe
 @ParametersAreNonnullByDefault
 public interface MessageProcessingDecorator {
     /**
@@ -35,78 +26,22 @@ public interface MessageProcessingDecorator {
      * @param context details about the message processing functionality, e.g. identifier for this message processor
      * @param message the message being processed
      */
-    default void onPreSupply(MessageProcessingContext context, Message message) {
+    default void onPreMessageProcessing(MessageProcessingContext context, Message message) {
 
     }
 
     /**
-     * Method called if the message listener threw an exception while supplying the message.
+     * Method called when the processing of the message has failed.
      *
-     * <p>If the message listener is synchronous, both this and {@link #onMessageProcessingFailure(MessageProcessingContext, Message, Throwable)}
-     * will be called with the same exception.
+     * <p>If the message listener is <b>synchronous</b> (it does not return a {@link CompletableFuture}), this method will be invoked if the message listener
+     * throws an exception. Execution of this method will be guaranteed to run on the same thread that the message listener was running in.
      *
-     * <p>This is guaranteed to be performed on the same thread as the message processing thread and will run before
-     * the {@link #onSupplyFinished(MessageProcessingContext, Message)} callback.
+     * <p>If the method is <b>asynchronous</b> (it returns a {@link CompletableFuture}), this method will be invoked if the message listener throws an exception
+     * or the return {@link CompletableFuture} is rejected. If an exception is thrown, this method will guaranteed to be run on the same thread that
+     * the message listener was running in. If the {@link CompletableFuture} is rejected, it is not guaranteed to be running on the same thread that
+     * was processing the message.
      *
-     * @param context   details about the message processing functionality, e.g. identifier for this message processor
-     * @param message   the message being processed
-     * @param throwable exception that was thrown by the message listener
-     */
-    default void onSupplyFailure(MessageProcessingContext context, Message message, Throwable throwable) {
-
-    }
-
-    /**
-     * Method called if the message processing thread did not throw an exception when supplying the message.
-     *
-     * <p>Note that this does not guarantee that the message resolving was actually completed as it could have returned a {@link CompletableFuture} indicating
-     * asynchronous processing or if the message consumer has the {@link Acknowledge} parameter and therefore controlling when it is a success.
-     *
-     * <p>For listening to when the message has been successfully processed, take a look at the
-     * {@link #onMessageProcessingSuccess(MessageProcessingContext, Message, Object)} method which will be called when the message
-     * was actually resolved via the {@link MessageResolver#resolveMessage(Message)} call.
-     *
-     * <p>This is guaranteed to be performed on the same thread as the message processing thread and will run before
-     * the {@link #onSupplyFinished(MessageProcessingContext, Message)} callback. If the message has been attempted to be supplied, either this method
-     * or {@link #onSupplyFailure(MessageProcessingContext, Message, Throwable)} are guaranteed to be run for the message.
-     *
-     * @param context details about the message processing functionality, e.g. identifier for this message processor
-     * @param message the message being processed
-     */
-    default void onSupplySuccess(MessageProcessingContext context, Message message) {
-
-    }
-
-    /**
-     * Method called when the message was successfully handed to the message listener for processing.
-     *
-     * <p>This does not guarantee that the message has finished processing as it could have been run on an asynchronous thread
-     * that is resolved independently or the message consumer will resolve the thread manually using the {@link Acknowledge}
-     * parameter.
-     *
-     * <p>If the message listener has started to process the message, this is guaranteed to be run regardless of the state of the message processing
-     * and will be executed on the same thread that was processing the message. Note that, if any of the
-     * {@link #onPreSupply(MessageProcessingContext, Message)} methods failed, the message listener will not be called and therefore this method
-     * will not be run.
-     *
-     * <p>This is guaranteed to be performed on the same thread as the message processing thread.
-     *
-     * @param context details about the message processing functionality, e.g. identifier for this message processor
-     * @param message the message being processed
-     */
-    default void onSupplyFinished(MessageProcessingContext context, Message message) {
-
-    }
-
-    /**
-     * Method called when the future for the message processing was completed exceptionally.
-     *
-     * <p>This will triggered if the message listener method returns a {@link CompletableFuture} that ends up being completed exceptionally. Another way
-     * is if the method completes successfully (synchronous or asynchronous), there is no {@link Acknowledge} argument and the subsequent call to
-     * {@link MessageResolver#resolveMessage(Message)} fails. In this case both this method and
-     * {@link #onMessageResolvedFailure(MessageProcessingContext, Message, Throwable)} will be called.
-     *
-     * <p>This will not be run on the thread that was processing the message.
+     * <p>If any of these decorators fail to perform this method, subsequent calls to the other decorators will still be performed.
      *
      * @param context   details about the message processing functionality, e.g. identifier for this message processor
      * @param message   the message being processed
@@ -117,44 +52,62 @@ public interface MessageProcessingDecorator {
     }
 
     /**
-     * Method called when the message has successfully been processed.
+     * Method called when the message has successfully been processed, but not necessarily that the message is considered a success and will be marked
+     * as resolved.
      *
-     * <p>This may or may not align with {@link #onSupplySuccess(MessageProcessingContext, Message)} if message listener is synchronous. However,
-     * the divergence for these methods occurs when the message listener processes the message asynchronously and
-     * this will be triggered once that asynchronous process is resolved, compared to {@link #onSupplySuccess(MessageProcessingContext, Message)} which
-     * is called when the message listener returns the {@link CompletableFuture}.
+     * <p>If the message listener is <b>synchronous</b> (it does not return a {@link CompletableFuture}), this method will be invoked if the message listener
+     * function is completed without throwing an exception. Execution of this method will be guaranteed to run on the same thread that the message listener was
+     * running in.
      *
-     * <p>This will not be run on the thread that was processing the message.
+     * <p>If the method is <b>asynchronous</b> (it returns a {@link CompletableFuture}), this method will be invoked if the message listener function returns a
+     * {@link CompletableFuture} and that is subsequently completed. This is not guaranteed to be running on the same thread that was processing the message.
      *
      * @param context details about the message processing functionality, e.g. identifier for this message processor
      * @param message the message being processed
-     * @param object  the value that was resolved from the message listener
+     * @param object  the value that was resolved from the message listener function or {@link CompletableFuture}
      */
     default void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
 
     }
 
     /**
-     * Method called when the message has completed, regardless of the result.
+     * Method called when the thread that was used to execute the message listener is done.
      *
-     * <p>This may or may not align with {@link #onSupplyFinished(MessageProcessingContext, Message)} if message listener is synchronous. However,
-     * the divergence for these methods occurs when the message listener processes the message asynchronously and
-     * this will be triggered once that asynchronous process is resolved, compared to {@link #onSupplySuccess(MessageProcessingContext, Message)} which
-     * is called when the message listener returns the {@link CompletableFuture}.
+     * <p>This can be used to tidy up any thread locals  that may have been set up in the {@link #onPreMessageProcessing(MessageProcessingContext, Message)}
+     * or within the message listener.
      *
-     * <p>This will not be run on the thread that was processing the message.
+     * <p>If the message listener is <b>synchronous</b> (it does not return a {@link CompletableFuture}), this method will be invoked when the message listener
+     * completes by returning or throwing an exception.
+     *
+     * <p>If the method is <b>asynchronous</b> (it returns a {@link CompletableFuture}), this method will be invoked if the message listener completes by
+     * returning the {@link CompletableFuture} or by throwing an exception.
+     *
+     * <p>This method is guaranteed to be run on the same thread that the message listener was running on.
      *
      * @param context details about the message processing functionality, e.g. identifier for this message processor
      * @param message the message being processed
      */
-    default void onMessageProcessingFinished(MessageProcessingContext context, Message message) {
+    default void onMessageProcessingThreadComplete(MessageProcessingContext context, Message message) {
 
     }
 
     /**
      * Method called if the message was successfully processed and the call to resolve the message was successful.
      *
-     * <p>This will not be run on the thread that was processing the message.
+     * <p>If the message listener is <b>synchronous</b> (it does not return a {@link CompletableFuture}) and <b>does not</b> have an {@link Acknowledge}
+     * argument, this method will be invoked if the message listener returns without throwing an exception and the message resolving process is
+     * completed successfully.
+     *
+     * <p>If the method is <b>asynchronous</b> (it returns a {@link CompletableFuture}) and <b>does not</b> have an {@link Acknowledge}
+     * argument, this method will be invoked if the message listener returns a completable future that is subsequently completed and the message resolving
+     * process is completed successfully.
+     *
+     * <p>If the message listener has an {@link Acknowledge} argument, this method will be invoked if the message listener calls
+     * {@link Acknowledge#acknowledgeSuccessful()} and the message resolving is completed unsuccessfully.
+     *
+     * <p>Execution of this method is not guaranteed to be run on the same thread that the message listener was running in. Also note that
+     * it is not guaranteed that either this or the {@link #onMessageResolvedFailure(MessageProcessingContext, Message, Throwable)} are not guaranteed to be
+     * executed as failure to process the message or not making a call to {@link Acknowledge} will not trigger the message resolving process to be run.
      *
      * @param context details about the message processing functionality, e.g. identifier for this message processor
      * @param message the message being processed
@@ -164,14 +117,25 @@ public interface MessageProcessingDecorator {
     }
 
     /**
-     * Method called if the message was was successfully processed and the attempt to resolve the message failed.
+     * Method called if the message was successfully processed but the call to resolve the message was unsuccessful.
      *
-     * <p>This can be useful in monitoring the underlying infrastructure failures for the message being successfully processed but it couldn't
-     * be removed from the SQS queue and therefore will be processed again if there is replaying setup. This could indicate wasted duplicate effort.
+     * <p>If the message listener is <b>synchronous</b> (it does not return a {@link CompletableFuture}) and <b>does not</b> have an {@link Acknowledge}
+     * argument, this method will be invoked if the message listener returns without throwing an exception and the message resolving process is
+     * completed unsuccessfully.
      *
-     * @param context   details about the message processing functionality, e.g. identifier for this message processor
-     * @param message   the message being processed
-     * @param throwable exception that was thrown by the {@link MessageResolver}
+     * <p>If the method is <b>asynchronous</b> (it returns a {@link CompletableFuture}) and <b>does not</b> have an {@link Acknowledge}
+     * argument, this method will be invoked if the message listener returns a completable future that is subsequently completed and the message resolving
+     * process is completed unsuccessfully.
+     *
+     * <p>If the message listener has an {@link Acknowledge} argument, this method will be invoked if the message listener calls
+     * {@link Acknowledge#acknowledgeSuccessful()} and the message resolving is completed unsuccessfully.
+     *
+     * <p>Execution of this method is not guaranteed to be run on the same thread that the message listener was running in. Also note that
+     * it is not guaranteed that either this or the {@link #onMessageResolvedSuccess(MessageProcessingContext, Message)} are not guaranteed to be executed
+     * as failure to process the message or not making a call to {@link Acknowledge} will not trigger the message resolving process to be run.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
      */
     default void onMessageResolvedFailure(MessageProcessingContext context, Message message, Throwable throwable) {
 

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
@@ -106,7 +106,7 @@ public interface MessageProcessingDecorator {
      * {@link Acknowledge#acknowledgeSuccessful()} and the message resolving is completed unsuccessfully.
      *
      * <p>Execution of this method is not guaranteed to be run on the same thread that the message listener was running in. Also note that
-     * it is not guaranteed that either this or the {@link #onMessageResolvedFailure(MessageProcessingContext, Message, Throwable)} are not guaranteed to be
+     * it is not guaranteed that either this or the {@link #onMessageResolvedFailure(MessageProcessingContext, Message, Throwable)} will be
      * executed as failure to process the message or not making a call to {@link Acknowledge} will not trigger the message resolving process to be run.
      *
      * @param context details about the message processing functionality, e.g. identifier for this message processor
@@ -131,7 +131,7 @@ public interface MessageProcessingDecorator {
      * {@link Acknowledge#acknowledgeSuccessful()} and the message resolving is completed unsuccessfully.
      *
      * <p>Execution of this method is not guaranteed to be run on the same thread that the message listener was running in. Also note that
-     * it is not guaranteed that either this or the {@link #onMessageResolvedSuccess(MessageProcessingContext, Message)} are not guaranteed to be executed
+     * it is not guaranteed that either this or the {@link #onMessageResolvedSuccess(MessageProcessingContext, Message)} will be executed
      * as failure to process the message or not making a call to {@link Acknowledge} will not trigger the message resolving process to be run.
      *
      * @param context details about the message processing functionality, e.g. identifier for this message processor

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/decorator/MessageProcessingDecorator.java
@@ -1,0 +1,179 @@
+package com.jashmore.sqs.decorator;
+
+import com.jashmore.sqs.processor.MessageProcessor;
+import com.jashmore.sqs.processor.argument.Acknowledge;
+import com.jashmore.sqs.resolver.MessageResolver;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Used to decorate the thread that will be used to process the given message.
+ *
+ * <p>This can be used to add extra information to the thread, such as Tracing, metrics, logging, etc.
+ *
+ * <p>For context on which each types of events that can be decorated, please take a look at the following key words:
+ * <ul>
+ *     <li><b>supply</b>: this represents the {@link MessageProcessor} handing (supplying) the message to the message listener to process the
+ *     message. Once the message listener function returns the supply task is deemed completed.
+ *     <li><b>processing</b>: this represents the actual logic the performs the message processing. If this process completes successfully it indicates that
+ *     the message listener succeeded and it should attempt to be resolved, however if it is completed unsuccessfully the message will not be resolved.
+ *     <li><b>resolve</b>: resolving a message represents the attempt to mark the message as completed successfully, e.g. calling to
+ *     {@link MessageResolver#resolveMessage(Message)}.
+ * </ul>
+ */
+@SuppressWarnings("unused")
+@ParametersAreNonnullByDefault
+public interface MessageProcessingDecorator {
+    /**
+     * Apply decorations to the thread before the message is handed to the message listener to process.
+     *
+     * <p>If any of these decorators fail to perform this method, subsequent calls will not be made and the message will not be
+     * processed by the underlying {@link MessageProcessor}.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     */
+    default void onPreSupply(MessageProcessingContext context, Message message) {
+
+    }
+
+    /**
+     * Method called if the message listener threw an exception while supplying the message.
+     *
+     * <p>If the message listener is synchronous, both this and {@link #onMessageProcessingFailure(MessageProcessingContext, Message, Throwable)}
+     * will be called with the same exception.
+     *
+     * <p>This is guaranteed to be performed on the same thread as the message processing thread and will run before
+     * the {@link #onSupplyFinished(MessageProcessingContext, Message)} callback.
+     *
+     * @param context   details about the message processing functionality, e.g. identifier for this message processor
+     * @param message   the message being processed
+     * @param throwable exception that was thrown by the message listener
+     */
+    default void onSupplyFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+
+    }
+
+    /**
+     * Method called if the message processing thread did not throw an exception when supplying the message.
+     *
+     * <p>Note that this does not guarantee that the message resolving was actually completed as it could have returned a {@link CompletableFuture} indicating
+     * asynchronous processing or if the message consumer has the {@link Acknowledge} parameter and therefore controlling when it is a success.
+     *
+     * <p>For listening to when the message has been successfully processed, take a look at the
+     * {@link #onMessageProcessingSuccess(MessageProcessingContext, Message, Object)} method which will be called when the message
+     * was actually resolved via the {@link MessageResolver#resolveMessage(Message)} call.
+     *
+     * <p>This is guaranteed to be performed on the same thread as the message processing thread and will run before
+     * the {@link #onSupplyFinished(MessageProcessingContext, Message)} callback. If the message has been attempted to be supplied, either this method
+     * or {@link #onSupplyFailure(MessageProcessingContext, Message, Throwable)} are guaranteed to be run for the message.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     */
+    default void onSupplySuccess(MessageProcessingContext context, Message message) {
+
+    }
+
+    /**
+     * Method called when the message was successfully handed to the message listener for processing.
+     *
+     * <p>This does not guarantee that the message has finished processing as it could have been run on an asynchronous thread
+     * that is resolved independently or the message consumer will resolve the thread manually using the {@link Acknowledge}
+     * parameter.
+     *
+     * <p>If the message listener has started to process the message, this is guaranteed to be run regardless of the state of the message processing
+     * and will be executed on the same thread that was processing the message. Note that, if any of the
+     * {@link #onPreSupply(MessageProcessingContext, Message)} methods failed, the message listener will not be called and therefore this method
+     * will not be run.
+     *
+     * <p>This is guaranteed to be performed on the same thread as the message processing thread.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     */
+    default void onSupplyFinished(MessageProcessingContext context, Message message) {
+
+    }
+
+    /**
+     * Method called when the future for the message processing was completed exceptionally.
+     *
+     * <p>This will triggered if the message listener method returns a {@link CompletableFuture} that ends up being completed exceptionally. Another way
+     * is if the method completes successfully (synchronous or asynchronous), there is no {@link Acknowledge} argument and the subsequent call to
+     * {@link MessageResolver#resolveMessage(Message)} fails. In this case both this method and
+     * {@link #onMessageResolvedFailure(MessageProcessingContext, Message, Throwable)} will be called.
+     *
+     * <p>This will not be run on the thread that was processing the message.
+     *
+     * @param context   details about the message processing functionality, e.g. identifier for this message processor
+     * @param message   the message being processed
+     * @param throwable the exception thrown
+     */
+    default void onMessageProcessingFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+
+    }
+
+    /**
+     * Method called when the message has successfully been processed.
+     *
+     * <p>This may or may not align with {@link #onSupplySuccess(MessageProcessingContext, Message)} if message listener is synchronous. However,
+     * the divergence for these methods occurs when the message listener processes the message asynchronously and
+     * this will be triggered once that asynchronous process is resolved, compared to {@link #onSupplySuccess(MessageProcessingContext, Message)} which
+     * is called when the message listener returns the {@link CompletableFuture}.
+     *
+     * <p>This will not be run on the thread that was processing the message.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     * @param object  the value that was resolved from the message listener
+     */
+    default void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+
+    }
+
+    /**
+     * Method called when the message has completed, regardless of the result.
+     *
+     * <p>This may or may not align with {@link #onSupplyFinished(MessageProcessingContext, Message)} if message listener is synchronous. However,
+     * the divergence for these methods occurs when the message listener processes the message asynchronously and
+     * this will be triggered once that asynchronous process is resolved, compared to {@link #onSupplySuccess(MessageProcessingContext, Message)} which
+     * is called when the message listener returns the {@link CompletableFuture}.
+     *
+     * <p>This will not be run on the thread that was processing the message.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     */
+    default void onMessageProcessingFinished(MessageProcessingContext context, Message message) {
+
+    }
+
+    /**
+     * Method called if the message was successfully processed and the call to resolve the message was successful.
+     *
+     * <p>This will not be run on the thread that was processing the message.
+     *
+     * @param context details about the message processing functionality, e.g. identifier for this message processor
+     * @param message the message being processed
+     */
+    default void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
+
+    }
+
+    /**
+     * Method called if the message was was successfully processed and the attempt to resolve the message failed.
+     *
+     * <p>This can be useful in monitoring the underlying infrastructure failures for the message being successfully processed but it couldn't
+     * be removed from the SQS queue and therefore will be processed again if there is replaying setup. This could indicate wasted duplicate effort.
+     *
+     * @param context   details about the message processing functionality, e.g. identifier for this message processor
+     * @param message   the message being processed
+     * @param throwable exception that was thrown by the {@link MessageResolver}
+     */
+    default void onMessageResolvedFailure(MessageProcessingContext context, Message message, Throwable throwable) {
+
+    }
+}

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessingException.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessingException.java
@@ -4,6 +4,10 @@ package com.jashmore.sqs.processor;
  * Exception thrown when the {@link MessageProcessor} has an exception processing a message.
  */
 public class MessageProcessingException extends RuntimeException {
+    public MessageProcessingException(Throwable cause) {
+        super(cause);
+    }
+
     public MessageProcessingException(final String message) {
         super(message);
     }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessingException.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessingException.java
@@ -4,15 +4,15 @@ package com.jashmore.sqs.processor;
  * Exception thrown when the {@link MessageProcessor} has an exception processing a message.
  */
 public class MessageProcessingException extends RuntimeException {
-    public MessageProcessingException(Throwable cause) {
-        super(cause);
-    }
-
     public MessageProcessingException(final String message) {
         super(message);
     }
 
     public MessageProcessingException(final String message, final Throwable cause) {
         super(message, cause);
+    }
+
+    public MessageProcessingException(final Throwable cause) {
+        super(cause);
     }
 }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
@@ -37,8 +37,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *     message callback is called</li>
  * </ul>
  *
- * <p>If you were to consider this library as similar to a pub-sub system, this could be considered the function that executes the underlying subscriber
- * in that it will take messages provided by the {@link MessageBroker}.
+ * <p>If you were to consider this library as similar to a pub-sub system, this could be considered the subscriber executor
+ * in that it will take messages provided by the {@link MessageBroker} and provide it to the message listener.
  *
  * <p>As there could be multiple messages all being processed at once, the implementations of this interface must be thread safe.
  */

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
@@ -14,10 +14,9 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Processor that has the responsibility of taking a message and processing it via the required message consumer (Java method).
  *
- * <p>This wraps a Java method that should be executed for each message received. The parameters of the function will need to extract data out
- * of the message and the implementations of this {@link MessageProcessor} should use the {@link ArgumentResolverService}. For example, an argument
- * may require a parameter to contain the message id of the message and therefore this would handle populating the argument for this parameter with
- * this value.
+ * <p>This wraps a Java method that should be executed for each message received. The parameters of the function will need to be extracted out
+ * of the message and the implementations of this {@link MessageProcessor} should use the {@link ArgumentResolverService} to do this. For example, an argument
+ * may require the message id of the message and therefore this would handle populating the argument for this parameter with this value.
  *
  * <p>Most arguments would be able to be resolved via the {@link ArgumentResolverService}, however, the following arguments must be resolved via
  * this {@link MessageProcessor}:
@@ -34,7 +33,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *     <li>the method has an {@link Acknowledge} field as a parameter, the {@link Acknowledge#acknowledgeSuccessful()} is called in the method and
  *     that is completed successfully</li>
  *     <li>or the method returns a {@link CompletableFuture} which is resolved, the process will call the resolve message callback after this</li>
- *     <li>or the method executes without throwing an exception, in which the resolve message callback is called</li>
+ *     <li>or the method does not return a {@link CompletableFuture} and executes without throwing an exception, in which the resolve
+ *     message callback is called</li>
  * </ul>
  *
  * <p>If you were to consider this library as similar to a pub-sub system, this could be considered the function that executes the underlying subscriber

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/MessageProcessor.java
@@ -8,6 +8,7 @@ import com.jashmore.sqs.resolver.MessageResolver;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -23,20 +24,21 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <ul>
  *     <li>{@link Acknowledge}: this argument can be used to acknowledge that the messages has been successfully processed and can be deleted from the
- *     queue.  If no {@link Acknowledge} argument is included in the argument list of the method, the message will be deleted from the queue if the
- *     method processing the message completes without an exception being thrown.</li>
+ *     queue.  If no {@link Acknowledge} argument is included in the argument list of the method, the message will be resolved based on the
+ *     execution and return type of the method.</li>
  *     <li>{@link VisibilityExtender}: this argument can be used to extend the visibility of a message if it is taking a long time to process.</li>
  * </ul>
  *
  * <p>A message can be considered a success and therefore deleted from the queue, see {@link MessageResolver}, if one of these scenarios occurs:
  * <ul>
- *     <li>the method has an {@link Acknowledge} field as a parameter and {@link Acknowledge#acknowledgeSuccessful()} is called in the method</li>
- *     <li>or the method returns a {@link CompletableFuture} which eventually is resolved</li>
- *     <li>or the method executes without throwing an exception</li>
+ *     <li>the method has an {@link Acknowledge} field as a parameter, the {@link Acknowledge#acknowledgeSuccessful()} is called in the method and
+ *     that is completed successfully</li>
+ *     <li>or the method returns a {@link CompletableFuture} which is resolved, the process will call the resolve message callback after this</li>
+ *     <li>or the method executes without throwing an exception, in which the resolve message callback is called</li>
  * </ul>
  *
- * <p>If you were to consider this library as similar to a pub-sub system, this could be considered the subscriber in that it will take messages provided
- * by the {@link MessageBroker}.
+ * <p>If you were to consider this library as similar to a pub-sub system, this could be considered the function that executes the underlying subscriber
+ * in that it will take messages provided by the {@link MessageBroker}.
  *
  * <p>As there could be multiple messages all being processed at once, the implementations of this interface must be thread safe.
  */
@@ -45,12 +47,19 @@ public interface MessageProcessor {
     /**
      * Process the message received on the queue.
      *
-     * <p>This method should return a {@link CompletableFuture} that is either resolved or rejected when the message is finished processing.
+     * <p>This method returns a {@link CompletableFuture} that is either resolved or rejected based on whether the message processing was able to be
+     * successfully completed. If the message processing is successful but the resolve message callback subsequently failed, the future will still be
+     * successful.
+     *
+     * <p>The completion of this future does not guarantee that the resolve callback was actually called because the message listener
+     * may be processing it asynchronously with the {@link Acknowledge} parameter.
      *
      * @param message                the message to process
      * @param resolveMessageCallback the callback that should be run when the message was processed successfully
-     * @return future that is resolved when the message was processed and another thread can be picked up, it should not return a rejected future
-     * @throws MessageProcessingException if there was an error processing the message, e.g. an exception was thrown by the delegate method
+     * @return future that is resolved when the message was processed and another thread can be picked up, if there was an error processing the message
+     *      this will be rejected with a {@link MessageProcessingException}
+     * @throws MessageProcessingException if the message could not be supplied to the message listener or the message listener failed without returning
+     *      the {@link CompletableFuture} when processing asynchronously
      */
-    CompletableFuture<?> processMessage(Message message, Runnable resolveMessageCallback) throws MessageProcessingException;
+    CompletableFuture<?> processMessage(Message message, Supplier<CompletableFuture<?>> resolveMessageCallback);
 }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
@@ -14,6 +14,8 @@ public interface Acknowledge {
      * Acknowledge that the message was successfully completed, which will result in it being removed from the queue.
      *
      * <p>Multiple calls to this has indeterminate behaviour and should not be done.
+     *
+     * @return the future that will be resolved if the message was succesfully resolved
      */
     CompletableFuture<?> acknowledgeSuccessful();
 }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
@@ -15,7 +15,7 @@ public interface Acknowledge {
      *
      * <p>Multiple calls to this has indeterminate behaviour and should not be done.
      *
-     * @return the future that will be resolved if the message was succesfully resolved
+     * @return the future that will be resolved if the message was successfully acknowledged
      */
     CompletableFuture<?> acknowledgeSuccessful();
 }

--- a/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
+++ b/java-dynamic-sqs-listener-api/src/main/java/com/jashmore/sqs/processor/argument/Acknowledge.java
@@ -1,5 +1,7 @@
 package com.jashmore.sqs.processor.argument;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Used to acknowledge the completion of a message being processed by the message consumer.
  *
@@ -13,5 +15,5 @@ public interface Acknowledge {
      *
      * <p>Multiple calls to this has indeterminate behaviour and should not be done.
      */
-    void acknowledgeSuccessful();
+    CompletableFuture<?> acknowledgeSuccessful();
 }

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
@@ -70,14 +70,9 @@ public class CoreMessageProcessor implements MessageProcessor {
         try {
             result = messageConsumerMethod.invoke(messageConsumerBean, arguments);
         } catch (IllegalAccessException exception) {
-            throw new MessageProcessingException(exception);
+            return CompletableFutureUtils.completedExceptionally(new MessageProcessingException(exception));
         } catch (InvocationTargetException exception) {
-            if (returnsCompletableFuture) {
-                // as this is an asynchronous message listener we would say this failed to supply the message
-                throw new MessageProcessingException("Message listener threw exception before returning CompletableFuture", exception.getCause());
-            } else {
-                return CompletableFutureUtils.completedExceptionally(new MessageProcessingException(exception.getCause()));
-            }
+            return CompletableFutureUtils.completedExceptionally(new MessageProcessingException(exception.getCause()));
         }
 
         if (hasAcknowledgeParameter) {
@@ -111,7 +106,7 @@ public class CoreMessageProcessor implements MessageProcessor {
         };
 
         return resultCompletableFuture
-                .thenCompose((ignored) -> resolveCallbackLoggingErrorsOnly.get());
+                .thenAccept((ignored) -> resolveCallbackLoggingErrorsOnly.get());
     }
 
     /**

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
@@ -90,9 +90,9 @@ public class CoreMessageProcessor implements MessageProcessor {
             resultCompletableFuture = CompletableFuture.completedFuture(null);
         }
 
-        final Supplier<CompletableFuture<Object>> resolveCallbackLoggingErrorsOnly = () -> {
+        final Runnable resolveCallbackLoggingErrorsOnly = () -> {
             try {
-                return resolveMessageCallback.get()
+                resolveMessageCallback.get()
                         .handle((i, throwable) -> {
                             if (throwable != null) {
                                 log.error("Error resolving successfully processed message", throwable);
@@ -101,12 +101,11 @@ public class CoreMessageProcessor implements MessageProcessor {
                         });
             } catch (RuntimeException runtimeException) {
                 log.error("Failed to trigger message resolving", runtimeException);
-                return CompletableFuture.completedFuture(null);
             }
         };
 
         return resultCompletableFuture
-                .thenAccept((ignored) -> resolveCallbackLoggingErrorsOnly.get());
+                .thenAccept((ignored) -> resolveCallbackLoggingErrorsOnly.run());
     }
 
     /**

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/CoreMessageProcessor.java
@@ -11,6 +11,7 @@ import com.jashmore.sqs.argument.visibility.DefaultVisibilityExtender;
 import com.jashmore.sqs.processor.argument.Acknowledge;
 import com.jashmore.sqs.processor.argument.VisibilityExtender;
 import com.jashmore.sqs.util.concurrent.CompletableFutureUtils;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 
@@ -20,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -27,6 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Default implementation of the {@link MessageProcessor} that will simply resolve arguments, process the message and delete the
  * message from the queue if it was completed successfully.
  */
+@Slf4j
 @ThreadSafe
 public class CoreMessageProcessor implements MessageProcessor {
     private final QueueProperties queueProperties;
@@ -36,8 +39,8 @@ public class CoreMessageProcessor implements MessageProcessor {
 
     // These are calculated in the constructor so that it is not recalculated each time a message is processed
     private final List<InternalArgumentResolver> methodArgumentResolvers;
-    private final Class<?> returnType;
     private final boolean hasAcknowledgeParameter;
+    private final boolean returnsCompletableFuture;
 
     public CoreMessageProcessor(final ArgumentResolverService argumentResolverService,
                                 final QueueProperties queueProperties,
@@ -51,18 +54,30 @@ public class CoreMessageProcessor implements MessageProcessor {
 
         this.methodArgumentResolvers = getArgumentResolvers(argumentResolverService);
         this.hasAcknowledgeParameter = hasAcknowledgeParameter();
-        this.returnType = messageConsumerMethod.getReturnType();
+        this.returnsCompletableFuture = CompletableFuture.class.isAssignableFrom(messageConsumerMethod.getReturnType());
     }
 
     @Override
-    public CompletableFuture<?> processMessage(final Message message, final Runnable resolveMessageCallback) throws MessageProcessingException {
-        final Object[] arguments = getArguments(message, resolveMessageCallback);
+    public CompletableFuture<?> processMessage(final Message message, final Supplier<CompletableFuture<?>> resolveMessageCallback) {
+        final Object[] arguments;
+        try {
+            arguments = getArguments(message, resolveMessageCallback);
+        } catch (RuntimeException runtimeException) {
+            throw new MessageProcessingException("Error building arguments for the message listener", runtimeException);
+        }
 
         final Object result;
         try {
             result = messageConsumerMethod.invoke(messageConsumerBean, arguments);
-        } catch (final InvocationTargetException | IllegalAccessException | RuntimeException exception) {
-            return CompletableFutureUtils.completedExceptionally(new MessageProcessingException("Error processing message", exception));
+        } catch (IllegalAccessException exception) {
+            throw new MessageProcessingException(exception);
+        } catch (InvocationTargetException exception) {
+            if (returnsCompletableFuture) {
+                // as this is an asynchronous message listener we would say this failed to supply the message
+                throw new MessageProcessingException("Message listener threw exception before returning CompletableFuture", exception.getCause());
+            } else {
+                return CompletableFutureUtils.completedExceptionally(new MessageProcessingException(exception.getCause()));
+            }
         }
 
         if (hasAcknowledgeParameter) {
@@ -70,19 +85,33 @@ public class CoreMessageProcessor implements MessageProcessor {
             return CompletableFuture.completedFuture(null);
         }
 
-        if (CompletableFuture.class.isAssignableFrom(returnType)) {
-            final CompletableFuture<?> resultCompletableFuture = (CompletableFuture) result;
-
-            if (resultCompletableFuture == null) {
+        final CompletableFuture<?> resultCompletableFuture;
+        if (returnsCompletableFuture) {
+            if (result == null) {
                 return CompletableFutureUtils.completedExceptionally(new MessageProcessingException("Method returns CompletableFuture but null was returned"));
             }
-
-            return resultCompletableFuture
-                    .thenAccept((ignored) -> resolveMessageCallback.run());
+            resultCompletableFuture = (CompletableFuture<?>) result;
         } else {
-            resolveMessageCallback.run();
-            return CompletableFuture.completedFuture(null);
+            resultCompletableFuture = CompletableFuture.completedFuture(null);
         }
+
+        final Supplier<CompletableFuture<Object>> resolveCallbackLoggingErrorsOnly = () -> {
+            try {
+                return resolveMessageCallback.get()
+                        .handle((i, throwable) -> {
+                            if (throwable != null) {
+                                log.error("Error resolving successfully processed message", throwable);
+                            }
+                            return null;
+                        });
+            } catch (RuntimeException runtimeException) {
+                log.error("Failed to trigger message resolving", runtimeException);
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        return resultCompletableFuture
+                .thenCompose((ignored) -> resolveCallbackLoggingErrorsOnly.get());
     }
 
     /**
@@ -91,7 +120,7 @@ public class CoreMessageProcessor implements MessageProcessor {
      * @param message     the message to populate the arguments from
      * @return the array of arguments to call the method with
      */
-    private Object[] getArguments(final Message message, final Runnable resolveMessageCallback) {
+    private Object[] getArguments(final Message message, final  Supplier<CompletableFuture<?>> resolveMessageCallback) {
         return methodArgumentResolvers.stream()
                 .map(resolver -> resolver.resolveArgument(message, resolveMessageCallback))
                 .toArray(Object[]::new);
@@ -110,7 +139,7 @@ public class CoreMessageProcessor implements MessageProcessor {
                             .build();
 
                     if (isAcknowledgeParameter(parameter)) {
-                        return (message, resolveMessageCallback) -> (Acknowledge) resolveMessageCallback::run;
+                        return (message, resolveMessageCallback) -> (Acknowledge) resolveMessageCallback::get;
                     }
 
                     if (isVisibilityExtenderParameter(parameter)) {
@@ -148,6 +177,6 @@ public class CoreMessageProcessor implements MessageProcessor {
          * @param resolveMessageCallback the callback that should be executed when the message has successfully been processed
          * @return the argument that should be used for the corresponding parameter
          */
-        Object resolveArgument(final Message message, final Runnable resolveMessageCallback);
+        Object resolveArgument(final Message message, final Supplier<CompletableFuture<?>> resolveMessageCallback);
     }
 }

--- a/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/DecoratingMessageProcessor.java
+++ b/java-dynamic-sqs-listener-core/src/main/java/com/jashmore/sqs/processor/DecoratingMessageProcessor.java
@@ -1,0 +1,91 @@
+package com.jashmore.sqs.processor;
+
+import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.decorator.MessageProcessingContext;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * {@link MessageProcessor} that will decorate the processing of the message using the supplied {@link MessageProcessingDecorator}s.
+ */
+@Slf4j
+public class DecoratingMessageProcessor implements MessageProcessor {
+    private final String listenerIdentifier;
+    private final QueueProperties queueProperties;
+    private final List<MessageProcessingDecorator> decorators;
+    private final MessageProcessor delegate;
+
+    public DecoratingMessageProcessor(final String listenerIdentifier,
+                                      final QueueProperties queueProperties,
+                                      final List<MessageProcessingDecorator> decorators,
+                                      final MessageProcessor delegate) {
+        this.listenerIdentifier = listenerIdentifier;
+        this.queueProperties = queueProperties;
+        this.decorators = decorators;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public CompletableFuture<?> processMessage(final Message message,
+                                               final Supplier<CompletableFuture<?>> resolveMessageCallback) throws MessageProcessingException {
+        final MessageProcessingContext context = MessageProcessingContext.builder()
+                .listenerIdentifier(listenerIdentifier)
+                .queueProperties(queueProperties)
+                .attributes(new HashMap<>())
+                .build();
+
+        decorators.forEach(decorator -> decorator.onPreSupply(context, message));
+        try {
+            final Supplier<CompletableFuture<?>> wrappedResolveMessageCallback = () -> resolveMessageCallback.get()
+                    .whenComplete((returnValue, throwable) -> {
+                        if (throwable != null) {
+                            safelyRun(decorators, decorator -> decorator.onMessageResolvedFailure(context, message, throwable));
+                        } else {
+                            safelyRun(decorators, decorator -> decorator.onMessageResolvedSuccess(context, message));
+                        }
+                    });
+
+            final CompletableFuture<?> resultingCompletableFuture = delegate.processMessage(message, wrappedResolveMessageCallback)
+                    .whenComplete((returnValue, throwable) -> {
+                        if (throwable != null) {
+                            safelyRun(decorators, decorator -> decorator.onMessageProcessingFailure(context, message, throwable));
+                        } else {
+                            safelyRun(decorators, decorator -> decorator.onMessageProcessingSuccess(context, message, returnValue));
+                        }
+                        safelyRun(decorators, decorator -> decorator.onMessageProcessingFinished(context, message));
+                    });
+            safelyRun(decorators, decorator -> decorator.onSupplySuccess(context, message));
+            return resultingCompletableFuture;
+        } catch (RuntimeException runtimeException) {
+            safelyRun(decorators, decorator -> decorator.onSupplyFailure(context, message, runtimeException));
+            throw runtimeException;
+        } finally {
+            safelyRun(decorators, decorator -> decorator.onSupplyFinished(context, message));
+        }
+    }
+
+    /**
+     * Used to run the {@link MessageProcessingDecorator} methods for each of the decorators, completing all regardless of whether a previous decorator
+     * failed.
+     *
+     * @param messageProcessingDecorators the decorators to consume
+     * @param decoratorConsumer           the consumer method that would be used to run one of the decorator methods
+     */
+    private void safelyRun(final List<MessageProcessingDecorator> messageProcessingDecorators,
+                           final Consumer<MessageProcessingDecorator> decoratorConsumer) {
+        messageProcessingDecorators.forEach((decorator) -> {
+            try {
+                decoratorConsumer.accept(decorator);
+            } catch (RuntimeException runtimeException) {
+                log.error("Error processing decorator: " + decorator.getClass().getSimpleName(), runtimeException);
+            }
+        });
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/AsynchronousMessageListenerScenarios.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/AsynchronousMessageListenerScenarios.java
@@ -1,0 +1,66 @@
+package com.jashmore.sqs.processor;
+
+import com.jashmore.sqs.processor.argument.Acknowledge;
+import com.jashmore.sqs.util.ExpectedTestException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@SuppressWarnings( {"unused", "WeakerAccess"})
+public class AsynchronousMessageListenerScenarios {
+
+    public CompletableFuture<?> methodReturningResolvedFuture() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public CompletableFuture<?> methodWithSuppliedFuture(CompletableFuture<?> future) {
+        return future;
+    }
+
+    public CompletableFuture<?> methodReturnFutureSubsequentlyResolved() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException interruptedException) {
+                // ignore
+            }
+        });
+    }
+
+    public CompletableFuture<?> methodReturnFutureSubsequentlyRejected() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException interruptedException) {
+                // ignore
+            }
+            throw new ExpectedTestException();
+        });
+    }
+
+    public CompletableFuture<?> methodThatThrowsException() {
+        throw new ExpectedTestException();
+    }
+
+    public CompletableFuture<?> methodThatReturnsNull() {
+        return null;
+    }
+
+    public CompletableFuture<?> methodWithAcknowledge(Acknowledge acknowledge) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public CompletableFuture<?> methodThatCallsAcknowledgeField(Acknowledge acknowledge) {
+        return acknowledge.acknowledgeSuccessful();
+    }
+
+    public static Method getMethod(final String methodName, final Class<?>... parameterClasses) {
+        try {
+            return AsynchronousMessageListenerScenarios.class.getDeclaredMethod(methodName, parameterClasses);
+        } catch (final NoSuchMethodException exception) {
+            throw new RuntimeException("Unable to find method for testing against", exception);
+        }
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/DecoratingMessageProcessorTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/DecoratingMessageProcessorTest.java
@@ -1,450 +1,1242 @@
 package com.jashmore.sqs.processor;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.jashmore.sqs.QueueProperties;
-import com.jashmore.sqs.decorator.MessageProcessingDecorator;
-import com.jashmore.sqs.decorator.MessageProcessingContext;
-import com.jashmore.sqs.util.ExpectedTestException;
-import com.jashmore.sqs.util.concurrent.CompletableFutureUtils;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.sqs.model.Message;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.HashMap;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
+import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.argument.ArgumentResolver;
+import com.jashmore.sqs.argument.ArgumentResolverService;
+import com.jashmore.sqs.decorator.MessageProcessingContext;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
+import com.jashmore.sqs.util.ExpectedTestException;
+import com.jashmore.sqs.util.concurrent.CompletableFutureUtils;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 @ExtendWith(MockitoExtension.class)
 class DecoratingMessageProcessorTest {
-
-    QueueProperties queueProperties = QueueProperties.builder().build();
+    QueueProperties QUEUE_PROPERTIES = QueueProperties.builder().build();
 
     MessageProcessingContext emptyContext = MessageProcessingContext.builder()
             .listenerIdentifier("identifier")
-            .queueProperties(queueProperties)
+            .queueProperties(QUEUE_PROPERTIES)
             .attributes(new HashMap<>())
             .build();
 
     Message message = Message.builder().body("body").build();
 
     @Mock
-    MessageProcessor delegate;
+    ArgumentResolverService argumentResolverService;
+
+    @Mock
+    SqsAsyncClient sqsAsyncClient;
 
     @Mock
     Supplier<CompletableFuture<?>> mockMessageResolver;
 
+    @Mock
+    private MessageProcessingDecorator decorator;
+
     @Nested
-    class Supply {
-        @Test
-        void decoratorsRunOnThreadProcessingMessage() {
-            // arrange
-            final Thread messageProcessingThread = Thread.currentThread();
-            final AtomicReference<Thread> preProcessorThread = new AtomicReference<>();
-            final AtomicReference<Thread> processorThread = new AtomicReference<>();
-            final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
-                @Override
-                public void onPreSupply(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
-                    preProcessorThread.set(Thread.currentThread());
-                }
-            };
-            final MessageProcessor delegate = (message, resolveMessageCallback) -> {
-                processorThread.set(Thread.currentThread());
-                return CompletableFuture.completedFuture(null);
-            };
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties, ImmutableList.of(decorator), delegate);
-
-            // act
-            processor.processMessage(message, mockMessageResolver);
-
-            // assert
-            assertThat(preProcessorThread.get()).isSameAs(messageProcessingThread);
-            assertThat(processorThread.get()).isSameAs(messageProcessingThread);
-        }
+    class OnPreMessageProcessing {
+        SynchronousMessageListenerScenarios synchronousMessageListener = new SynchronousMessageListenerScenarios();
 
         @Test
-        void anyFailingPreProcessWillNotProcessTheMessage() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(RuntimeException.class).when(decorator).onPreSupply(any(), any());
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+        void isCalledWithAnEmptyContext() {
+            // when
+            final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+            final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
                     ImmutableList.of(decorator), delegate);
-
-            // act
-            assertThrows(RuntimeException.class, () -> processor.processMessage(message, mockMessageResolver));
-
-            // assert
-            verify(delegate, never()).processMessage(any(), any());
-        }
-
-        @Test
-        void preProcessorAreCalledWithMessageDetailsAndMessage() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build(),
-                    ImmutableList.of(decorator), delegate);
-            when(delegate.processMessage(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+            when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
             // act
             processor.processMessage(message, mockMessageResolver);
 
             // assert
-            verify(decorator).onPreSupply(emptyContext, message);
+            verify(decorator).onPreMessageProcessing(eq(emptyContext), eq(message));
         }
 
         @Test
-        void onSuccessWillCallOnSupplySuccessAndFinished() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build(),
-                    ImmutableList.of(decorator), delegate);
-            when(delegate.processMessage(any(), any())).thenReturn(new CompletableFuture<>());
-
-            // act
-            processor.processMessage(message, mockMessageResolver);
-
-            // assert
-            verify(decorator).onSupplySuccess(emptyContext, message);
-            verify(decorator, never()).onSupplyFailure(eq(emptyContext), eq(message), any());
-            verify(decorator).onSupplyFinished(emptyContext, message);
-            InOrder inOrder = inOrder(decorator, delegate);
-            inOrder.verify(delegate).processMessage(any(), any());
-            inOrder.verify(decorator).onSupplySuccess(any(), any());
-            inOrder.verify(decorator).onSupplyFinished(any(), any());
-        }
-
-        @Test
-        void willSupplyFailureWillCallOnSupplyFailureAndFinished() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build()
-                    , ImmutableList.of(decorator), delegate);
-            when(delegate.processMessage(any(), any())).thenThrow(ExpectedTestException.class);
-
-            // act
-            final ExpectedTestException exception = assertThrows(ExpectedTestException.class, () -> processor.processMessage(message, mockMessageResolver));
-
-            // assert
-            verify(decorator, never()).onSupplySuccess(emptyContext, message);
-            verify(decorator).onSupplyFailure(emptyContext, message, exception);
-            verify(decorator).onSupplyFinished(emptyContext, message);
-            InOrder inOrder = inOrder(decorator, delegate);
-            inOrder.verify(delegate).processMessage(any(), any());
-            inOrder.verify(decorator).onSupplyFailure(emptyContext, message, exception);
-            inOrder.verify(decorator).onSupplyFinished(emptyContext, message);
-        }
-
-        @Test
-        void anyFailingOnSupplySuccessDecoratorWillNotStopOtherDecoratorsRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onSupplySuccess(any(), any());
+        void anyFailureWillNotRunSubsequentDecorators() {
+            // when
+            final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+            final MessageProcessingDecorator failingDecorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(failingDecorator).onPreMessageProcessing(any(), any());
             final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFuture.completedFuture("value")).when(delegate).processMessage(any(), any());
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                    ImmutableList.of(failingDecorator, otherDecorator), createCoreProcessor(synchronousMessageListener, method));
 
             // act
-            processor.processMessage(message, mockMessageResolver);
+            final MessageProcessingException exception = assertThrows(MessageProcessingException.class,
+                    () -> processor.processMessage(message, mockMessageResolver));
 
             // assert
-            verify(otherDecorator).onSupplySuccess(any(), any());
+            assertThat(exception).hasCauseInstanceOf(ExpectedTestException.class);
+            verify(otherDecorator, never()).onPreMessageProcessing(any(), any());
         }
 
         @Test
-        void anyFailingOnSupplyFailureDecoratorWillNotStopOtherDecoratorsRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onSupplyFailure(any(), any(), any());
+        void anyFailureWillNotDelegateMessageProcessor() {
+            // when
+            final MessageProcessingDecorator failingDecorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(failingDecorator).onPreMessageProcessing(any(), any());
             final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            when(delegate.processMessage(any(), any())).thenThrow(ExpectedTestException.class);
+            final MessageProcessor delegateProcessor = mock(MessageProcessor.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                    ImmutableList.of(failingDecorator, otherDecorator), delegateProcessor);
 
             // act
-            assertThrows(ExpectedTestException.class, () -> processor.processMessage(message, mockMessageResolver));
+            assertThrows(MessageProcessingException.class,
+                    () -> processor.processMessage(message, mockMessageResolver));
 
             // assert
-            verify(otherDecorator).onSupplyFailure(any(), any(), any());
-        }
-
-        @Test
-        void anyFailingOnSupplyFinishedDecoratorWillNotStopOtherDecoratorsRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onSupplyFinished(any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            when(delegate.processMessage(any(), any())).thenReturn(new CompletableFuture<>());
-
-            // act
-            processor.processMessage(message, mockMessageResolver);
-
-            // assert
-            verify(otherDecorator).onSupplyFinished(any(), any());
+            verify(delegateProcessor, never()).processMessage(any(), any());
         }
     }
 
     @Nested
-    class MessageProcessing {
-        @Test
-        void willCallMessageProcessingFunctionsOnMessageProcessingSuccess() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator), delegate);
-            final CompletableFuture<String> future = new CompletableFuture<>();
-            doReturn(future).when(delegate).processMessage(any(), any());
-            processor.processMessage(message, mockMessageResolver);
+    class Asynchronous {
+        AsynchronousMessageListenerScenarios asynchronousMessageListenerScenarios = new AsynchronousMessageListenerScenarios();
 
-            // act
-            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
-            future.complete("value");
+        @Mock
+        ArgumentResolver<CompletableFuture<?>> futureArgumentResolver;
 
-            // assert
-            verify(decorator).onMessageProcessingSuccess(emptyContext, message, "value");
-            verify(decorator, never()).onMessageProcessingFailure(any(), any(), any());
-            verify(decorator).onMessageProcessingFinished(emptyContext, message);
+        @Nested
+        class OnMessageProcessingSuccess {
+
+            @Test
+            void isCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodWithSuppliedFuture", CompletableFuture.class);
+                doReturn(futureArgumentResolver).when(argumentResolverService).getArgumentResolver(any());
+                final CompletableFuture<?> methodFuture = new CompletableFuture<>();
+                doReturn(methodFuture).when(futureArgumentResolver).resolveArgumentForParameter(any(), any(), any());
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                final CompletableFuture<?> future = processor.processMessage(message, mockMessageResolver);
+                assertThat(future).isNotDone();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+                methodFuture.complete(null);
+
+                // assert
+                verify(decorator).onMessageProcessingSuccess(eq(emptyContext), eq(message), isNull());
+            }
+
+            @Test
+            void isNotCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                final CompletableFuture<?> completableFuture = processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(completableFuture).isCompletedExceptionally();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadAsMessageListener() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                @ParametersAreNonnullByDefault
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            @SneakyThrows
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingSuccess(any(), any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(otherDecorator).onMessageProcessingSuccess(any(), any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(decorator).onMessageProcessingSuccess(eq(contextReference.get()), eq(message), isNull());
+            }
         }
 
-        @Test
-        void willCallMessageProcessingFunctionsOnMessageProcessingFailure() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator), delegate);
-            final CompletableFuture<String> future = new CompletableFuture<>();
-            doReturn(future).when(delegate).processMessage(any(), any());
-            processor.processMessage(message, mockMessageResolver);
+        @Nested
+        class OnMessageProcessingFailure {
 
-            // act
-            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
-            final ExpectedTestException exception = new ExpectedTestException();
-            future.completeExceptionally(exception);
+            @Test
+            void isNotCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodWithSuppliedFuture", CompletableFuture.class);
+                doReturn(futureArgumentResolver).when(argumentResolverService).getArgumentResolver(any());
+                final CompletableFuture<?> methodFuture = new CompletableFuture<>();
+                doReturn(methodFuture).when(futureArgumentResolver).resolveArgumentForParameter(any(), any(), any());
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // assert
-            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
-            verify(decorator).onMessageProcessingFailure(emptyContext, message, exception);
-            verify(decorator).onMessageProcessingFinished(emptyContext, message);
+                // act
+                final CompletableFuture<?> future = processor.processMessage(message, mockMessageResolver);
+                assertThat(future).isNotDone();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+                methodFuture.complete(null);
+
+                // assert
+                verify(decorator, never()).onMessageProcessingFailure(eq(emptyContext), eq(message), any());
+            }
+
+            @Test
+            void isCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                final CompletableFuture<?> completableFuture = processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(completableFuture).isCompletedExceptionally();
+                verify(decorator).onMessageProcessingFailure(eq(emptyContext), eq(message), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadAsMessageListener() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyRejected");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                @ParametersAreNonnullByDefault
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingFailure(MessageProcessingContext context, Message message, Throwable object) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                assertThrows(ExecutionException.class, () -> processor.processMessage(message, mockMessageResolver).get(5, SECONDS));
+
+                // assert
+                assertThat(decoratorThread).isNotNull();
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            @SneakyThrows
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyRejected");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFailure(any(), any(), any());
+
+                // act
+                assertThrows(ExecutionException.class, () -> processor.processMessage(message, mockMessageResolver).get(5, SECONDS));
+
+                // assert
+                verify(otherDecorator).onMessageProcessingFailure(any(), any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyRejected");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+
+                // act
+                assertThrows(ExecutionException.class, () -> processor.processMessage(message, mockMessageResolver).get(5, SECONDS));
+
+                // assert
+                verify(decorator).onMessageProcessingFailure(eq(contextReference.get()), eq(message), any());
+            }
         }
 
-        @Test
-        void anyFailingOnMessageProcessingSuccessDecoratorWillNotStopOtherDecoratorsFromRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingSuccess(any(), any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFuture.completedFuture("value")).when(delegate).processMessage(any(), any());
+        @Nested
+        class OnMessageProcessingThreadComplete {
 
-            // act
-            processor.processMessage(message, mockMessageResolver);
+            @Test
+            void isCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodWithSuppliedFuture", CompletableFuture.class);
+                doReturn(futureArgumentResolver).when(argumentResolverService).getArgumentResolver(any());
+                final CompletableFuture<?> methodFuture = new CompletableFuture<>();
+                doReturn(methodFuture).when(futureArgumentResolver).resolveArgumentForParameter(any(), any(), any());
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // assert
-            verify(otherDecorator).onMessageProcessingSuccess(any(), any(), any());
+                // act
+                final CompletableFuture<?> future = processor.processMessage(message, mockMessageResolver);
+                assertThat(future).isNotDone();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+                methodFuture.complete(null);
+
+                // assert
+                verify(decorator).onMessageProcessingThreadComplete(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            void isCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                final CompletableFuture<?> completableFuture = processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(completableFuture).isCompletedExceptionally();
+                verify(decorator).onMessageProcessingThreadComplete(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            @SneakyThrows
+            void isCalledOnTheSameThreadAsMessageListener() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingThreadComplete(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                assertThat(decoratorThread.get()).isEqualTo(currentThread);
+            }
+
+            @Test
+            @SneakyThrows
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingThreadComplete(any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(otherDecorator).onMessageProcessingThreadComplete(any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(decorator).onMessageProcessingThreadComplete(eq(contextReference.get()), eq(message));
+            }
         }
 
-        @Test
-        void anyFailingOnMessageProcessingFailureDecoratorWillNotStopOtherDecoratorsFromRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFailure(any(), any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+        @Nested
+        class OnMessageResolvedSuccess {
 
-            // act
-            processor.processMessage(message, mockMessageResolver);
+            @Test
+            void isCalledOnMessageListenerSuccessAndResolvingSuccess() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodWithSuppliedFuture", CompletableFuture.class);
+                doReturn(futureArgumentResolver).when(argumentResolverService).getArgumentResolver(any());
+                final CompletableFuture<?> methodFuture = new CompletableFuture<>();
+                doReturn(methodFuture).when(futureArgumentResolver).resolveArgumentForParameter(any(), any(), any());
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // assert
-            verify(otherDecorator).onMessageProcessingFailure(any(), any(), any());
+                // act
+                final CompletableFuture<?> future = processor.processMessage(message, mockMessageResolver);
+                assertThat(future).isNotDone();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+                methodFuture.complete(null);
+
+                // assert
+                verify(decorator).onMessageResolvedSuccess(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            void isNotCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                final CompletableFuture<?> completableFuture = processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(completableFuture).isCompletedExceptionally();
+                verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            }
+
+            @Test
+            void isNotCalledWhenMessageResolvingIsRejected() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyRejected");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                assertThrows(ExecutionException.class, () -> processor.processMessage(message, mockMessageResolver).get(5, SECONDS));
+
+                // assert
+                verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadAsMessageListener() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageResolvedSuccess(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenAnswer(invocation -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException interruptedException) {
+                        // do nothing
+                    }
+                }));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            @SneakyThrows
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedSuccess(any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(otherDecorator).onMessageResolvedSuccess(any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(decorator).onMessageResolvedSuccess(eq(contextReference.get()), eq(message));
+            }
         }
 
-        @Test
-        void anyFailingOnMessageProcessingFinishedDecoratorWillNotStopOtherDecoratorsFromRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFinished(any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+        @Nested
+        class OnMessageResolvedFailure {
 
-            // act
-            processor.processMessage(message, mockMessageResolver);
+            @Test
+            void isCalledOnMessageListenerSuccessAndResolvingFailure() {
+                // arrange
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodWithSuppliedFuture", CompletableFuture.class);
+                doReturn(futureArgumentResolver).when(argumentResolverService).getArgumentResolver(any());
+                final CompletableFuture<?> methodFuture = new CompletableFuture<>();
+                doReturn(methodFuture).when(futureArgumentResolver).resolveArgumentForParameter(any(), any(), any());
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
 
-            // assert
-            verify(otherDecorator).onMessageProcessingFinished(any(), any());
+                // act
+                final CompletableFuture<?> future = processor.processMessage(message, mockMessageResolver);
+                assertThat(future).isNotDone();
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+                methodFuture.complete(null);
+
+                // assert
+                verify(decorator).onMessageResolvedFailure(eq(emptyContext), eq(message), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledWhenMessageResolvingIsSuccessful() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturningResolvedFuture");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(decorator, never()).onMessageResolvedFailure(any(), any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadAsMessageListener() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageResolvedFailure(@Nonnull MessageProcessingContext context, @Nonnull Message message, @Nonnull Throwable throwable) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, asynchronousMessageListenerScenarios);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenAnswer(invocation -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException interruptedException) {
+                        // do nothing
+                    }
+                    throw new ExpectedTestException();
+                }));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            @SneakyThrows
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedFailure(any(), any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(otherDecorator).onMessageResolvedFailure(any(), any(), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = AsynchronousMessageListenerScenarios.getMethod("methodReturnFutureSubsequentlyResolved");
+                final MessageProcessor delegate = createCoreProcessor(asynchronousMessageListenerScenarios, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
+
+                // act
+                processor.processMessage(message, mockMessageResolver).get(5, SECONDS);
+
+                // assert
+                verify(decorator).onMessageResolvedFailure(eq(contextReference.get()), eq(message), any());
+            }
         }
     }
 
     @Nested
-    class MessageResolve {
+    class Synchronous {
+        SynchronousMessageListenerScenarios synchronousMessageListener = new SynchronousMessageListenerScenarios();
 
-        @Captor
-        ArgumentCaptor<Supplier<CompletableFuture<?>>> resolverSupplierCaptor;
+        @Nested
+        class OnMessageProcessingSuccess {
+            @Test
+            void isCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-        @Test
-        void willCallOnMessageResolveDecoratorsOnMessageResolveSuccess() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator), delegate);
-            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
-            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
-            processor.processMessage(message, mockMessageResolver);
+                // act
+                processor.processMessage(message, mockMessageResolver);
 
-            // act
-            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
-            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
-            resolverSupplierCaptor.getValue().get(); // trigger resolved
+                // assert
+                verify(decorator).onMessageProcessingSuccess(eq(emptyContext), eq(message), isNull());
+            }
 
-            // assert
-            verify(decorator).onMessageResolvedSuccess(emptyContext, message);
-            verify(decorator, never()).onMessageResolvedFailure(any(), any(), any());
+            @Test
+            void isNotCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+            }
+
+            @Test
+            void isCalledOnTheSameThreadOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                @ParametersAreNonnullByDefault final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(decoratorThread.get()).isEqualTo(currentThread);
+            }
+
+            @Test
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingSuccess(any(), any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(otherDecorator).onMessageProcessingSuccess(any(), any(), any());
+            }
+
+            @Test
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageProcessingSuccess(eq(contextReference.get()), eq(message), isNull());
+            }
         }
 
-        @Test
-        void willCallOnMessageResolveDecoratorsOnMessageResolveFailure() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator), delegate);
-            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
-            final ExpectedTestException exception = new ExpectedTestException();
-            doReturn(CompletableFutureUtils.completedExceptionally(exception)).when(mockMessageResolver).get();
-            processor.processMessage(message, mockMessageResolver);
+        @Nested
+        class OnMessageProcessingFailure {
+            @Test
+            void isNotCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // act
-            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
-            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
-            resolverSupplierCaptor.getValue().get(); // trigger resolved
+                // act
+                processor.processMessage(message, mockMessageResolver);
 
-            // assert
-            verify(decorator, never()).onMessageResolvedSuccess(emptyContext, message);
-            verify(decorator).onMessageResolvedFailure(emptyContext, message, exception);
+                // assert
+                verify(decorator, never()).onMessageProcessingFailure(any(), any(), any());
+            }
+
+            @Test
+            void isCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageProcessingFailure(any(), any(), any());
+            }
+
+            @Test
+            void isCalledOnTheSameThreadOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingFailure(@Nonnull MessageProcessingContext context, @Nonnull Message message, @Nonnull Throwable object) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(decoratorThread.get()).isEqualTo(currentThread);
+            }
+
+            @Test
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFailure(any(), any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(otherDecorator).onMessageProcessingFailure(any(), any(), any());
+            }
+
+            @Test
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageProcessingFailure(eq(contextReference.get()), eq(message), any());
+            }
         }
 
-        @Test
-        void anyFailingOnMessageResolveSuccessDecoratorWillNotStopOtherDecoratorsFromRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedSuccess(any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
-            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
-            processor.processMessage(message, mockMessageResolver);
+        @Nested
+        class OnMessageProcessingThreadComplete {
+            @Test
+            void isCalledOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // act
-            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
-            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
-            resolverSupplierCaptor.getValue().get(); // trigger resolved
+                // act
+                processor.processMessage(message, mockMessageResolver);
 
-            // assert
-            verify(otherDecorator).onMessageResolvedSuccess(any(), any());
+                // assert
+                verify(decorator).onMessageProcessingThreadComplete(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            void isNotCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageProcessingThreadComplete(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            void isCalledOnTheSameThreadOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageProcessingThreadComplete(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        decoratorThread.set(Thread.currentThread());
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                assertThat(decoratorThread.get()).isEqualTo(currentThread);
+            }
+
+            @Test
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingThreadComplete(any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(otherDecorator).onMessageProcessingThreadComplete(any(), any());
+            }
+
+            @Test
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageProcessingThreadComplete(eq(contextReference.get()), eq(message));
+            }
         }
 
-        @Test
-        void anyFailingOnMessageResolveFailureDecoratorWillNotStopOtherDecoratorsFromRunning() {
-            // arrange
-            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
-            doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedFailure(any(), any(), any());
-            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, otherDecorator), delegate);
-            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
-            final ExpectedTestException exception = new ExpectedTestException();
-            doReturn(CompletableFutureUtils.completedExceptionally(exception)).when(mockMessageResolver).get();
-            processor.processMessage(message, mockMessageResolver);
+        @Nested
+        class OnMessageResolvedSuccess {
+            @Test
+            void isCalledOnMessageListenerSuccessAndResolveSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
 
-            // act
-            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
-            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
-            resolverSupplierCaptor.getValue().get(); // trigger resolved
+                // act
+                processor.processMessage(message, mockMessageResolver);
 
-            // assert
-            verify(otherDecorator).onMessageResolvedFailure(any(), any(), any());
+                // assert
+                verify(decorator).onMessageResolvedSuccess(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            void isNotCalledWhenMessageListenerThrowsException() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodThatThrowsException");
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator, never()).onMessageResolvedSuccess(eq(emptyContext), eq(message));
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final CountDownLatch resolvingComplete = new CountDownLatch(1);
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageResolvedSuccess(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        decoratorThread.set(Thread.currentThread());
+                        resolvingComplete.countDown();
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenAnswer(invocation -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException interruptedException) {
+                        // do nothing
+                    }
+                }));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+                assertThat(resolvingComplete.await(1, TimeUnit.SECONDS)).isTrue();
+
+                // assert
+                assertThat(decoratorThread.get()).isNotNull();
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedSuccess(any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(otherDecorator).onMessageResolvedSuccess(any(), any());
+            }
+
+            @Test
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageResolvedSuccess(eq(contextReference.get()), eq(message));
+            }
+        }
+
+        @Nested
+        class OnMessageResolvedFailure {
+            @Test
+            void isCalledOnMessageListenerSuccessAndResolveFailure() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageResolvedFailure(eq(emptyContext), eq(message), any());
+            }
+
+            @Test
+            @SneakyThrows
+            void isNotCalledOnTheSameThreadOnMessageListenerSuccess() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final AtomicReference<Thread> decoratorThread = new AtomicReference<>();
+                final CountDownLatch resolvingComplete = new CountDownLatch(1);
+                final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onMessageResolvedFailure(@Nonnull MessageProcessingContext context, @Nonnull Message message, @Nonnull Throwable throwable) {
+                        decoratorThread.set(Thread.currentThread());
+                        resolvingComplete.countDown();
+                    }
+                };
+                final MessageProcessor delegate = new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                        sqsAsyncClient, method, synchronousMessageListener);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator), delegate);
+                when(mockMessageResolver.get()).thenAnswer(invocation -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException interruptedException) {
+                        // do nothing
+                    }
+                    throw new ExpectedTestException();
+                }));
+                final Thread currentThread = Thread.currentThread();
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+                assertThat(resolvingComplete.await(1, TimeUnit.SECONDS)).isTrue();
+
+                // assert
+                assertThat(decoratorThread.get()).isNotNull();
+                assertThat(decoratorThread.get()).isNotEqualTo(currentThread);
+            }
+
+            @Test
+            void willCallSubsequentDecoratorsIfOneFails() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(decorator, otherDecorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
+                doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedFailure(any(), any(), any());
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(otherDecorator).onMessageResolvedFailure(any(), any(), any());
+            }
+
+            @Test
+            void sameContextIsAppliedThroughDecorator() {
+                // when
+                final Method method = SynchronousMessageListenerScenarios.getMethod("methodWithNoArguments");
+                final MessageProcessor delegate = createCoreProcessor(synchronousMessageListener, method);
+                final AtomicReference<MessageProcessingContext> contextReference = new AtomicReference<>();
+                final MessageProcessingDecorator otherDecorator = new MessageProcessingDecorator() {
+                    @Override
+                    public void onPreMessageProcessing(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                        contextReference.set(context);
+                    }
+                };
+                final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QUEUE_PROPERTIES,
+                        ImmutableList.of(otherDecorator, decorator), delegate);
+                when(mockMessageResolver.get()).thenReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException()));
+
+                // act
+                processor.processMessage(message, mockMessageResolver);
+
+                // assert
+                verify(decorator).onMessageResolvedFailure(eq(contextReference.get()), eq(message), any());
+            }
         }
     }
 
-    @Nested
-    class Context {
-        @Captor
-        ArgumentCaptor<Supplier<CompletableFuture<?>>> resolverSupplierCaptor;
-
-        @Test
-        void contextIsSharedBetweenEachStageOfProcessing() {
-            // arrange
-            @ParametersAreNonnullByDefault
-            final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
-                @Override
-                public void onPreSupply(MessageProcessingContext context, Message message) {
-                    context.setAttribute("onPreSupply", "onPreSupplyValue");
-                }
-
-                @Override
-                public void onSupplySuccess(MessageProcessingContext context, Message message) {
-                    context.setAttribute("onSupplySuccess", "onSupplySuccessValue");
-
-                }
-
-                @Override
-                public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
-                    context.setAttribute("onMessageProcessingSuccess", "onMessageProcessingSuccessValue");
-
-                }
-
-                @Override
-                public void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
-                    context.setAttribute("onMessageResolvedSuccess", "onMessageResolvedSuccessValue");
-                }
-            };
-            final MessageProcessingDecorator mockDecorator = mock(MessageProcessingDecorator.class);
-            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
-                    ImmutableList.of(decorator, mockDecorator), delegate);
-            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
-            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
-
-            // act
-            processor.processMessage(message, mockMessageResolver);
-            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
-            resolverSupplierCaptor.getValue().get(); // trigger resolved
-
-            // assert
-            final ArgumentCaptor<MessageProcessingContext> contextArgumentCaptor = ArgumentCaptor.forClass(MessageProcessingContext.class);
-            verify(mockDecorator).onMessageResolvedSuccess(contextArgumentCaptor.capture(), eq(message));
-            assertThat(contextArgumentCaptor.getValue().getAttributes()).isEqualTo(ImmutableMap.of(
-                    "onPreSupply", "onPreSupplyValue",
-                    "onSupplySuccess", "onSupplySuccessValue",
-                    "onMessageProcessingSuccess", "onMessageProcessingSuccessValue",
-                    "onMessageResolvedSuccess", "onMessageResolvedSuccessValue"
-            ));
-        }
+    private CoreMessageProcessor createCoreProcessor(final Object bean, final Method method) {
+        return new CoreMessageProcessor(argumentResolverService, QUEUE_PROPERTIES,
+                sqsAsyncClient, method, bean);
     }
 }

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/DecoratingMessageProcessorTest.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/DecoratingMessageProcessorTest.java
@@ -1,0 +1,450 @@
+package com.jashmore.sqs.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.jashmore.sqs.QueueProperties;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
+import com.jashmore.sqs.decorator.MessageProcessingContext;
+import com.jashmore.sqs.util.ExpectedTestException;
+import com.jashmore.sqs.util.concurrent.CompletableFutureUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DecoratingMessageProcessorTest {
+
+    QueueProperties queueProperties = QueueProperties.builder().build();
+
+    MessageProcessingContext emptyContext = MessageProcessingContext.builder()
+            .listenerIdentifier("identifier")
+            .queueProperties(queueProperties)
+            .attributes(new HashMap<>())
+            .build();
+
+    Message message = Message.builder().body("body").build();
+
+    @Mock
+    MessageProcessor delegate;
+
+    @Mock
+    Supplier<CompletableFuture<?>> mockMessageResolver;
+
+    @Nested
+    class Supply {
+        @Test
+        void decoratorsRunOnThreadProcessingMessage() {
+            // arrange
+            final Thread messageProcessingThread = Thread.currentThread();
+            final AtomicReference<Thread> preProcessorThread = new AtomicReference<>();
+            final AtomicReference<Thread> processorThread = new AtomicReference<>();
+            final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                @Override
+                public void onPreSupply(@Nonnull MessageProcessingContext context, @Nonnull Message message) {
+                    preProcessorThread.set(Thread.currentThread());
+                }
+            };
+            final MessageProcessor delegate = (message, resolveMessageCallback) -> {
+                processorThread.set(Thread.currentThread());
+                return CompletableFuture.completedFuture(null);
+            };
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties, ImmutableList.of(decorator), delegate);
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            assertThat(preProcessorThread.get()).isSameAs(messageProcessingThread);
+            assertThat(processorThread.get()).isSameAs(messageProcessingThread);
+        }
+
+        @Test
+        void anyFailingPreProcessWillNotProcessTheMessage() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(RuntimeException.class).when(decorator).onPreSupply(any(), any());
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator), delegate);
+
+            // act
+            assertThrows(RuntimeException.class, () -> processor.processMessage(message, mockMessageResolver));
+
+            // assert
+            verify(delegate, never()).processMessage(any(), any());
+        }
+
+        @Test
+        void preProcessorAreCalledWithMessageDetailsAndMessage() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build(),
+                    ImmutableList.of(decorator), delegate);
+            when(delegate.processMessage(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(decorator).onPreSupply(emptyContext, message);
+        }
+
+        @Test
+        void onSuccessWillCallOnSupplySuccessAndFinished() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build(),
+                    ImmutableList.of(decorator), delegate);
+            when(delegate.processMessage(any(), any())).thenReturn(new CompletableFuture<>());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(decorator).onSupplySuccess(emptyContext, message);
+            verify(decorator, never()).onSupplyFailure(eq(emptyContext), eq(message), any());
+            verify(decorator).onSupplyFinished(emptyContext, message);
+            InOrder inOrder = inOrder(decorator, delegate);
+            inOrder.verify(delegate).processMessage(any(), any());
+            inOrder.verify(decorator).onSupplySuccess(any(), any());
+            inOrder.verify(decorator).onSupplyFinished(any(), any());
+        }
+
+        @Test
+        void willSupplyFailureWillCallOnSupplyFailureAndFinished() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", QueueProperties.builder().build()
+                    , ImmutableList.of(decorator), delegate);
+            when(delegate.processMessage(any(), any())).thenThrow(ExpectedTestException.class);
+
+            // act
+            final ExpectedTestException exception = assertThrows(ExpectedTestException.class, () -> processor.processMessage(message, mockMessageResolver));
+
+            // assert
+            verify(decorator, never()).onSupplySuccess(emptyContext, message);
+            verify(decorator).onSupplyFailure(emptyContext, message, exception);
+            verify(decorator).onSupplyFinished(emptyContext, message);
+            InOrder inOrder = inOrder(decorator, delegate);
+            inOrder.verify(delegate).processMessage(any(), any());
+            inOrder.verify(decorator).onSupplyFailure(emptyContext, message, exception);
+            inOrder.verify(decorator).onSupplyFinished(emptyContext, message);
+        }
+
+        @Test
+        void anyFailingOnSupplySuccessDecoratorWillNotStopOtherDecoratorsRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onSupplySuccess(any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFuture.completedFuture("value")).when(delegate).processMessage(any(), any());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(otherDecorator).onSupplySuccess(any(), any());
+        }
+
+        @Test
+        void anyFailingOnSupplyFailureDecoratorWillNotStopOtherDecoratorsRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onSupplyFailure(any(), any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            when(delegate.processMessage(any(), any())).thenThrow(ExpectedTestException.class);
+
+            // act
+            assertThrows(ExpectedTestException.class, () -> processor.processMessage(message, mockMessageResolver));
+
+            // assert
+            verify(otherDecorator).onSupplyFailure(any(), any(), any());
+        }
+
+        @Test
+        void anyFailingOnSupplyFinishedDecoratorWillNotStopOtherDecoratorsRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onSupplyFinished(any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            when(delegate.processMessage(any(), any())).thenReturn(new CompletableFuture<>());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(otherDecorator).onSupplyFinished(any(), any());
+        }
+    }
+
+    @Nested
+    class MessageProcessing {
+        @Test
+        void willCallMessageProcessingFunctionsOnMessageProcessingSuccess() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator), delegate);
+            final CompletableFuture<String> future = new CompletableFuture<>();
+            doReturn(future).when(delegate).processMessage(any(), any());
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+            future.complete("value");
+
+            // assert
+            verify(decorator).onMessageProcessingSuccess(emptyContext, message, "value");
+            verify(decorator, never()).onMessageProcessingFailure(any(), any(), any());
+            verify(decorator).onMessageProcessingFinished(emptyContext, message);
+        }
+
+        @Test
+        void willCallMessageProcessingFunctionsOnMessageProcessingFailure() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator), delegate);
+            final CompletableFuture<String> future = new CompletableFuture<>();
+            doReturn(future).when(delegate).processMessage(any(), any());
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+            final ExpectedTestException exception = new ExpectedTestException();
+            future.completeExceptionally(exception);
+
+            // assert
+            verify(decorator, never()).onMessageProcessingSuccess(any(), any(), any());
+            verify(decorator).onMessageProcessingFailure(emptyContext, message, exception);
+            verify(decorator).onMessageProcessingFinished(emptyContext, message);
+        }
+
+        @Test
+        void anyFailingOnMessageProcessingSuccessDecoratorWillNotStopOtherDecoratorsFromRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingSuccess(any(), any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFuture.completedFuture("value")).when(delegate).processMessage(any(), any());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(otherDecorator).onMessageProcessingSuccess(any(), any(), any());
+        }
+
+        @Test
+        void anyFailingOnMessageProcessingFailureDecoratorWillNotStopOtherDecoratorsFromRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFailure(any(), any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(otherDecorator).onMessageProcessingFailure(any(), any(), any());
+        }
+
+        @Test
+        void anyFailingOnMessageProcessingFinishedDecoratorWillNotStopOtherDecoratorsFromRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onMessageProcessingFinished(any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+
+            // assert
+            verify(otherDecorator).onMessageProcessingFinished(any(), any());
+        }
+    }
+
+    @Nested
+    class MessageResolve {
+
+        @Captor
+        ArgumentCaptor<Supplier<CompletableFuture<?>>> resolverSupplierCaptor;
+
+        @Test
+        void willCallOnMessageResolveDecoratorsOnMessageResolveSuccess() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator), delegate);
+            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
+            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
+            resolverSupplierCaptor.getValue().get(); // trigger resolved
+
+            // assert
+            verify(decorator).onMessageResolvedSuccess(emptyContext, message);
+            verify(decorator, never()).onMessageResolvedFailure(any(), any(), any());
+        }
+
+        @Test
+        void willCallOnMessageResolveDecoratorsOnMessageResolveFailure() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator), delegate);
+            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
+            final ExpectedTestException exception = new ExpectedTestException();
+            doReturn(CompletableFutureUtils.completedExceptionally(exception)).when(mockMessageResolver).get();
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
+            resolverSupplierCaptor.getValue().get(); // trigger resolved
+
+            // assert
+            verify(decorator, never()).onMessageResolvedSuccess(emptyContext, message);
+            verify(decorator).onMessageResolvedFailure(emptyContext, message, exception);
+        }
+
+        @Test
+        void anyFailingOnMessageResolveSuccessDecoratorWillNotStopOtherDecoratorsFromRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedSuccess(any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
+            resolverSupplierCaptor.getValue().get(); // trigger resolved
+
+            // assert
+            verify(otherDecorator).onMessageResolvedSuccess(any(), any());
+        }
+
+        @Test
+        void anyFailingOnMessageResolveFailureDecoratorWillNotStopOtherDecoratorsFromRunning() {
+            // arrange
+            final MessageProcessingDecorator decorator = mock(MessageProcessingDecorator.class);
+            doThrow(ExpectedTestException.class).when(decorator).onMessageResolvedFailure(any(), any(), any());
+            final MessageProcessingDecorator otherDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, otherDecorator), delegate);
+            doReturn(CompletableFutureUtils.completedExceptionally(new ExpectedTestException())).when(delegate).processMessage(any(), any());
+            final ExpectedTestException exception = new ExpectedTestException();
+            doReturn(CompletableFutureUtils.completedExceptionally(exception)).when(mockMessageResolver).get();
+            processor.processMessage(message, mockMessageResolver);
+
+            // act
+            verify(decorator, never()).onMessageResolvedSuccess(any(), any());
+            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
+            resolverSupplierCaptor.getValue().get(); // trigger resolved
+
+            // assert
+            verify(otherDecorator).onMessageResolvedFailure(any(), any(), any());
+        }
+    }
+
+    @Nested
+    class Context {
+        @Captor
+        ArgumentCaptor<Supplier<CompletableFuture<?>>> resolverSupplierCaptor;
+
+        @Test
+        void contextIsSharedBetweenEachStageOfProcessing() {
+            // arrange
+            @ParametersAreNonnullByDefault
+            final MessageProcessingDecorator decorator = new MessageProcessingDecorator() {
+                @Override
+                public void onPreSupply(MessageProcessingContext context, Message message) {
+                    context.setAttribute("onPreSupply", "onPreSupplyValue");
+                }
+
+                @Override
+                public void onSupplySuccess(MessageProcessingContext context, Message message) {
+                    context.setAttribute("onSupplySuccess", "onSupplySuccessValue");
+
+                }
+
+                @Override
+                public void onMessageProcessingSuccess(MessageProcessingContext context, Message message, Object object) {
+                    context.setAttribute("onMessageProcessingSuccess", "onMessageProcessingSuccessValue");
+
+                }
+
+                @Override
+                public void onMessageResolvedSuccess(MessageProcessingContext context, Message message) {
+                    context.setAttribute("onMessageResolvedSuccess", "onMessageResolvedSuccessValue");
+                }
+            };
+            final MessageProcessingDecorator mockDecorator = mock(MessageProcessingDecorator.class);
+            final DecoratingMessageProcessor processor = new DecoratingMessageProcessor("identifier", queueProperties,
+                    ImmutableList.of(decorator, mockDecorator), delegate);
+            doReturn(CompletableFuture.completedFuture(null)).when(delegate).processMessage(any(), any());
+            doReturn(CompletableFuture.completedFuture(null)).when(mockMessageResolver).get();
+
+            // act
+            processor.processMessage(message, mockMessageResolver);
+            verify(delegate).processMessage(eq(message), resolverSupplierCaptor.capture());
+            resolverSupplierCaptor.getValue().get(); // trigger resolved
+
+            // assert
+            final ArgumentCaptor<MessageProcessingContext> contextArgumentCaptor = ArgumentCaptor.forClass(MessageProcessingContext.class);
+            verify(mockDecorator).onMessageResolvedSuccess(contextArgumentCaptor.capture(), eq(message));
+            assertThat(contextArgumentCaptor.getValue().getAttributes()).isEqualTo(ImmutableMap.of(
+                    "onPreSupply", "onPreSupplyValue",
+                    "onSupplySuccess", "onSupplySuccessValue",
+                    "onMessageProcessingSuccess", "onMessageProcessingSuccessValue",
+                    "onMessageResolvedSuccess", "onMessageResolvedSuccessValue"
+            ));
+        }
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/SynchronousMessageListenerScenarios.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/processor/SynchronousMessageListenerScenarios.java
@@ -1,0 +1,56 @@
+package com.jashmore.sqs.processor;
+
+import com.jashmore.sqs.argument.payload.Payload;
+import com.jashmore.sqs.processor.argument.Acknowledge;
+import com.jashmore.sqs.processor.argument.VisibilityExtender;
+import com.jashmore.sqs.util.ExpectedTestException;
+
+import java.lang.reflect.Method;
+
+@SuppressWarnings( {"unused", "WeakerAccess"})
+public class SynchronousMessageListenerScenarios {
+
+    public void methodWithNoArguments() {
+        sleep();
+    }
+
+    public void methodWithArguments(@Payload String payload, @Payload String payloadTwo) {
+        sleep();
+    }
+
+    public void methodThatThrowsException() {
+        throw new ExpectedTestException();
+    }
+
+    public void methodThatCallsAcknowledgeField(Acknowledge acknowledge) {
+        acknowledge.acknowledgeSuccessful();
+    }
+
+    public void methodWithAcknowledge(Acknowledge acknowledge) {
+        sleep();
+    }
+
+    public void methodWithVisibilityExtender(VisibilityExtender visibilityExtender) {
+        sleep();
+    }
+
+    private void privateMethod() {
+        sleep();
+    }
+
+    public static Method getMethod(final String methodName, final Class<?>... parameterClasses) {
+        try {
+            return SynchronousMessageListenerScenarios.class.getDeclaredMethod(methodName, parameterClasses);
+        } catch (final NoSuchMethodException exception) {
+            throw new RuntimeException("Unable to find method for testing against", exception);
+        }
+    }
+
+    public void sleep() {
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException interruptedException) {
+            throw new RuntimeException(interruptedException);
+        }
+    }
+}

--- a/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/util/thread/ThreadTestUtils.java
+++ b/java-dynamic-sqs-listener-core/src/test/java/com/jashmore/sqs/util/thread/ThreadTestUtils.java
@@ -19,9 +19,10 @@ public class ThreadTestUtils {
         }
     }
 
+    @SuppressWarnings("BusyWait")
     public static void waitUntilThreadInState(Thread thread, Thread.State expectedState) throws InterruptedException {
         int numberOfTimesCompleted = 0;
-        while (thread.getState() != expectedState && numberOfTimesCompleted < 30) {
+        while (thread.getState() != expectedState && numberOfTimesCompleted < 60) {
             Thread.sleep(100);
             numberOfTimesCompleted++;
         }

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
@@ -199,6 +199,7 @@ public class QueueListenerConfiguration {
                                                                                         final SqsAsyncClientProvider sqsAsyncClientProvider,
                                                                                         final QueueResolver queueResolver,
                                                                                         final Environment environment,
+                                                                                        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
                                                                                         final List<MessageProcessingDecorator> decorators) {
                 return new BasicMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider,
                         queueResolver, environment, decorators);
@@ -209,6 +210,7 @@ public class QueueListenerConfiguration {
                                                                                               final SqsAsyncClientProvider sqsAsyncClientProvider,
                                                                                               final QueueResolver queueResolver,
                                                                                               final Environment environment,
+                                                                                              @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
                                                                                               final List<MessageProcessingDecorator> decorators) {
                 return new PrefetchingMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider,
                         queueResolver, environment, decorators);

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/config/QueueListenerConfiguration.java
@@ -12,6 +12,7 @@ import com.jashmore.sqs.argument.messageid.MessageIdArgumentResolver;
 import com.jashmore.sqs.argument.payload.PayloadArgumentResolver;
 import com.jashmore.sqs.argument.payload.mapper.JacksonPayloadMapper;
 import com.jashmore.sqs.container.MessageListenerContainer;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
 import com.jashmore.sqs.spring.client.DefaultSqsAsyncClientProvider;
 import com.jashmore.sqs.spring.client.SqsAsyncClientProvider;
 import com.jashmore.sqs.spring.container.DefaultMessageListenerContainerCoordinator;
@@ -197,16 +198,20 @@ public class QueueListenerConfiguration {
             public MessageListenerContainerFactory basicMessageListenerContainerFactory(final ArgumentResolverService argumentResolverService,
                                                                                         final SqsAsyncClientProvider sqsAsyncClientProvider,
                                                                                         final QueueResolver queueResolver,
-                                                                                        final Environment environment) {
-                return new BasicMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider, queueResolver, environment);
+                                                                                        final Environment environment,
+                                                                                        final List<MessageProcessingDecorator> decorators) {
+                return new BasicMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider,
+                        queueResolver, environment, decorators);
             }
 
             @Bean
             public MessageListenerContainerFactory prefetchingMessageListenerContainerFactory(final ArgumentResolverService argumentResolverService,
                                                                                               final SqsAsyncClientProvider sqsAsyncClientProvider,
                                                                                               final QueueResolver queueResolver,
-                                                                                              final Environment environment) {
-                return new PrefetchingMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider, queueResolver, environment);
+                                                                                              final Environment environment,
+                                                                                              final List<MessageProcessingDecorator> decorators) {
+                return new PrefetchingMessageListenerContainerFactory(argumentResolverService, sqsAsyncClientProvider,
+                        queueResolver, environment, decorators);
             }
         }
     }

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/BasicMessageListenerContainerFactory.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/BasicMessageListenerContainerFactory.java
@@ -9,7 +9,9 @@ import com.jashmore.sqs.broker.concurrent.StaticConcurrentMessageBrokerPropertie
 import com.jashmore.sqs.container.CoreMessageListenerContainer;
 import com.jashmore.sqs.container.MessageListenerContainer;
 import com.jashmore.sqs.container.StaticCoreMessageListenerContainerProperties;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
 import com.jashmore.sqs.processor.CoreMessageProcessor;
+import com.jashmore.sqs.processor.DecoratingMessageProcessor;
 import com.jashmore.sqs.processor.MessageProcessor;
 import com.jashmore.sqs.resolver.MessageResolver;
 import com.jashmore.sqs.resolver.batching.BatchingMessageResolver;
@@ -31,6 +33,7 @@ import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -44,6 +47,7 @@ public class BasicMessageListenerContainerFactory extends AbstractAnnotationMess
     private final SqsAsyncClientProvider sqsAsyncClientProvider;
     private final QueueResolver queueResolver;
     private final Environment environment;
+    private final List<MessageProcessingDecorator> messageProcessingDecorators;
 
     @Override
     protected Class<QueueListener> getAnnotationClass() {
@@ -60,11 +64,12 @@ public class BasicMessageListenerContainerFactory extends AbstractAnnotationMess
                 .build();
 
 
+        final String identifier = IdentifierUtils.buildIdentifierForMethod(annotation.identifier(), bean.getClass(), method);
         return new CoreMessageListenerContainer(
-                IdentifierUtils.buildIdentifierForMethod(annotation.identifier(), bean.getClass(), method),
+                identifier,
                 buildMessageBrokerSupplier(annotation),
                 buildMessageRetrieverSupplier(annotation, queueProperties, sqsAsyncClient),
-                buildProcessorSupplier(queueProperties, sqsAsyncClient, bean, method),
+                buildProcessorSupplier(identifier, queueProperties, sqsAsyncClient, bean, method),
                 buildMessageResolver(annotation, queueProperties, sqsAsyncClient),
                 StaticCoreMessageListenerContainerProperties.builder()
                         .shouldProcessAnyExtraRetrievedMessagesOnShutdown(annotation.processAnyExtraRetrievedMessagesOnShutdown())
@@ -80,11 +85,19 @@ public class BasicMessageListenerContainerFactory extends AbstractAnnotationMess
                 .build());
     }
 
-    private Supplier<MessageProcessor> buildProcessorSupplier(final QueueProperties queueProperties,
+    private Supplier<MessageProcessor> buildProcessorSupplier(final String identifier,
+                                                              final QueueProperties queueProperties,
                                                               final SqsAsyncClient sqsAsyncClient,
                                                               final Object bean,
                                                               final Method method) {
-        return () -> new CoreMessageProcessor(argumentResolverService, queueProperties, sqsAsyncClient, method, bean);
+        return () -> {
+            final CoreMessageProcessor delegateProcessor = new CoreMessageProcessor(argumentResolverService, queueProperties, sqsAsyncClient, method, bean);
+            if (messageProcessingDecorators.isEmpty()) {
+                return delegateProcessor;
+            } else {
+                return new DecoratingMessageProcessor(identifier, queueProperties, messageProcessingDecorators, delegateProcessor);
+            }
+        };
     }
 
     private Supplier<MessageRetriever> buildMessageRetrieverSupplier(final QueueListener annotation,

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactory.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactory.java
@@ -9,7 +9,9 @@ import com.jashmore.sqs.broker.concurrent.StaticConcurrentMessageBrokerPropertie
 import com.jashmore.sqs.container.CoreMessageListenerContainer;
 import com.jashmore.sqs.container.MessageListenerContainer;
 import com.jashmore.sqs.container.StaticCoreMessageListenerContainerProperties;
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
 import com.jashmore.sqs.processor.CoreMessageProcessor;
+import com.jashmore.sqs.processor.DecoratingMessageProcessor;
 import com.jashmore.sqs.processor.MessageProcessor;
 import com.jashmore.sqs.resolver.MessageResolver;
 import com.jashmore.sqs.resolver.batching.BatchingMessageResolver;
@@ -30,6 +32,7 @@ import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -43,6 +46,7 @@ public class PrefetchingMessageListenerContainerFactory extends AbstractAnnotati
     private final SqsAsyncClientProvider sqsAsyncClientProvider;
     private final QueueResolver queueResolver;
     private final Environment environment;
+    private final List<MessageProcessingDecorator> messageProcessingDecorators;
 
     @Override
     protected Class<PrefetchingQueueListener> getAnnotationClass() {
@@ -60,11 +64,12 @@ public class PrefetchingMessageListenerContainerFactory extends AbstractAnnotati
                 .queueUrl(queueResolver.resolveQueueUrl(sqsAsyncClient, annotation.value()))
                 .build();
 
+        final String identifier = IdentifierUtils.buildIdentifierForMethod(annotation.identifier(), bean.getClass(), method);
         return new CoreMessageListenerContainer(
-                IdentifierUtils.buildIdentifierForMethod(annotation.identifier(), bean.getClass(), method),
+                identifier,
                 buildMessageBrokerSupplier(annotation),
                 buildMessageRetrieverSupplier(annotation, queueProperties, sqsAsyncClient),
-                buildProcessorSupplier(queueProperties, sqsAsyncClient, bean, method),
+                buildProcessorSupplier(identifier, queueProperties, sqsAsyncClient, bean, method),
                 buildMessageResolverSupplier(queueProperties, sqsAsyncClient),
                 StaticCoreMessageListenerContainerProperties.builder()
                         .shouldProcessAnyExtraRetrievedMessagesOnShutdown(annotation.processAnyExtraRetrievedMessagesOnShutdown())
@@ -87,11 +92,19 @@ public class PrefetchingMessageListenerContainerFactory extends AbstractAnnotati
     }
 
 
-    private Supplier<MessageProcessor> buildProcessorSupplier(final QueueProperties queueProperties,
+    private Supplier<MessageProcessor> buildProcessorSupplier(final String identifier,
+                                                              final QueueProperties queueProperties,
                                                               final SqsAsyncClient sqsAsyncClient,
                                                               final Object bean,
                                                               final Method method) {
-        return () -> new CoreMessageProcessor(argumentResolverService, queueProperties, sqsAsyncClient, method, bean);
+        return () -> {
+            final CoreMessageProcessor delegateProcessor = new CoreMessageProcessor(argumentResolverService, queueProperties, sqsAsyncClient, method, bean);
+            if (messageProcessingDecorators.isEmpty()) {
+                return delegateProcessor;
+            } else {
+                return new DecoratingMessageProcessor(identifier, queueProperties, messageProcessingDecorators, delegateProcessor);
+            }
+        };
     }
 
     private int getConcurrencyLevel(final PrefetchingQueueListener annotation) {

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/basic/QueueListenerMessageDecoratorIntegrationTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/basic/QueueListenerMessageDecoratorIntegrationTest.java
@@ -1,0 +1,74 @@
+package it.com.jashmore.sqs.container.basic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
+import com.jashmore.sqs.decorator.MessageProcessingContext;
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient;
+import com.jashmore.sqs.spring.config.QueueListenerConfiguration;
+import com.jashmore.sqs.spring.container.basic.QueueListener;
+import com.jashmore.sqs.util.LocalSqsAsyncClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+
+@Slf4j
+@SpringBootTest(classes = {QueueListenerMessageDecoratorIntegrationTest.TestConfig.class, QueueListenerConfiguration.class})
+public class QueueListenerMessageDecoratorIntegrationTest {
+    private static final String QUEUE_NAME = "QueueListenerMessageDecoratorIntegrationTest";
+    private static final AtomicReference<String> mdcValue = new AtomicReference<>();
+    private static final CountDownLatch MESSAGE_PROCESSED_LATCH = new CountDownLatch(1);
+
+    @Autowired
+    private LocalSqsAsyncClient localSqsAsyncClient;
+
+    @Configuration
+    public static class TestConfig {
+        @Bean
+        public LocalSqsAsyncClient localSqsAsyncClient() {
+            return new ElasticMqSqsAsyncClient(QUEUE_NAME);
+        }
+
+        @Bean
+        public MessageProcessingDecorator mdcDecorator() {
+            return new MessageProcessingDecorator() {
+                @Override
+                public void onPreSupply(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
+                    MDC.put("test", "value");
+                }
+            };
+        }
+
+        @Service
+        public static class MessageListener {
+            @QueueListener(value = QUEUE_NAME)
+            public void listenToMessage() {
+                mdcValue.set(MDC.get("test"));
+                MESSAGE_PROCESSED_LATCH.countDown();
+            }
+        }
+    }
+
+    @Test
+    void messageProcessingBeansWillWrapMessageProcessing() throws Exception {
+        // arrange
+        localSqsAsyncClient.sendMessage(QUEUE_NAME, "message");
+
+        // act
+        assertThat(MESSAGE_PROCESSED_LATCH.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // assert
+        assertThat(mdcValue).hasValue("value");
+    }
+}

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/basic/QueueListenerMessageDecoratorIntegrationTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/basic/QueueListenerMessageDecoratorIntegrationTest.java
@@ -44,7 +44,7 @@ public class QueueListenerMessageDecoratorIntegrationTest {
         public MessageProcessingDecorator mdcDecorator() {
             return new MessageProcessingDecorator() {
                 @Override
-                public void onPreSupply(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
+                public void onPreMessageProcessing(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
                     MDC.put("test", "value");
                 }
             };

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/prefetch/PrefetchingQueueListenerMessageDecoratorIntegrationTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/prefetch/PrefetchingQueueListenerMessageDecoratorIntegrationTest.java
@@ -1,0 +1,74 @@
+package it.com.jashmore.sqs.container.prefetch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jashmore.sqs.decorator.MessageProcessingDecorator;
+import com.jashmore.sqs.decorator.MessageProcessingContext;
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient;
+import com.jashmore.sqs.spring.config.QueueListenerConfiguration;
+import com.jashmore.sqs.spring.container.prefetch.PrefetchingQueueListener;
+import com.jashmore.sqs.util.LocalSqsAsyncClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+
+@Slf4j
+@SpringBootTest(classes = {PrefetchingQueueListenerMessageDecoratorIntegrationTest.TestConfig.class, QueueListenerConfiguration.class})
+public class PrefetchingQueueListenerMessageDecoratorIntegrationTest {
+    private static final String QUEUE_NAME = "PrefetchingQueueListenerMessageDecoratorIntegrationTest";
+    private static final AtomicReference<String> mdcValue = new AtomicReference<>();
+    private static final CountDownLatch MESSAGE_PROCESSED_LATCH = new CountDownLatch(1);
+
+    @Autowired
+    private LocalSqsAsyncClient localSqsAsyncClient;
+
+    @Configuration
+    public static class TestConfig {
+        @Bean
+        public LocalSqsAsyncClient localSqsAsyncClient() {
+            return new ElasticMqSqsAsyncClient(QUEUE_NAME);
+        }
+
+        @Bean
+        public MessageProcessingDecorator mdcDecorator() {
+            return new MessageProcessingDecorator() {
+                @Override
+                public void onPreSupply(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
+                    MDC.put("test", "value");
+                }
+            };
+        }
+
+        @Service
+        public static class MessageListener {
+            @PrefetchingQueueListener(value = QUEUE_NAME)
+            public void listenToMessage() {
+                mdcValue.set(MDC.get("test"));
+                MESSAGE_PROCESSED_LATCH.countDown();
+            }
+        }
+    }
+
+    @Test
+    void messageProcessingBeansWillWrapMessageProcessing() throws Exception {
+        // arrange
+        localSqsAsyncClient.sendMessage(QUEUE_NAME, "message");
+
+        // act
+        assertThat(MESSAGE_PROCESSED_LATCH.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // assert
+        assertThat(mdcValue).hasValue("value");
+    }
+}

--- a/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/prefetch/PrefetchingQueueListenerMessageDecoratorIntegrationTest.java
+++ b/java-dynamic-sqs-listener-spring/java-dynamic-sqs-listener-spring-core/src/test/java/it/com/jashmore/sqs/container/prefetch/PrefetchingQueueListenerMessageDecoratorIntegrationTest.java
@@ -44,7 +44,7 @@ public class PrefetchingQueueListenerMessageDecoratorIntegrationTest {
         public MessageProcessingDecorator mdcDecorator() {
             return new MessageProcessingDecorator() {
                 @Override
-                public void onPreSupply(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
+                public void onPreMessageProcessing(@Nonnull final MessageProcessingContext context, @Nonnull final Message message) {
                     MDC.put("test", "value");
                 }
             };

--- a/util/elasticmq-sqs-client/pom.xml
+++ b/util/elasticmq-sqs-client/pom.xml
@@ -11,6 +11,9 @@
 
     <artifactId>elasticmq-sqs-client</artifactId>
 
+    <name>Java Dynamic SQS Listener - Utilities - ElasticMQ Sqs Async Client</name>
+    <description>Provides the ability to create a SqsAsyncClient backed by an in-memory ElasticMQ SQS Server</description>
+
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
Adds a MessageProcessorDecorator functionality which allows consumers of the listener to wrap the message processing to implement certain logic, like tracing, metrics, etc.