### PR TITLE
fixes #223: fix shutdown race condition

### DIFF
--- a/core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
@@ -8,7 +8,6 @@ import lombok.Value;
 @Value
 @Builder(toBuilder = true)
 public class StaticCoreMessageListenerContainerProperties implements CoreMessageListenerContainerProperties {
-    String messageProcessingThreadNameFormat;
     Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown;
     Boolean shouldInterruptThreadsProcessingMessagesOnShutdown;
     Integer messageProcessingShutdownTimeoutInSeconds;

--- a/core/src/main/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolver.java
+++ b/core/src/main/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolver.java
@@ -91,7 +91,7 @@ public class BatchingMessageResolver implements MessageResolver {
         final ExecutorService executorService = buildExecutorServiceForSendingBatchDeletion();
         // all of the batches currently being sent so that they can be waited on during shutdown
         final List<CompletableFuture<?>> batchesBeingPublished = new ArrayList<>();
-        while (continueProcessing) {
+        while (!Thread.currentThread().isInterrupted() && continueProcessing) {
             final List<MessageResolutionBean> batchOfMessagesToResolve = new LinkedList<>();
             try {
                 final int batchSize = getBatchSize();

--- a/core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
+++ b/core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
@@ -45,7 +45,6 @@ class CoreMessageListenerContainerTest {
     private static final StaticCoreMessageListenerContainerProperties DEFAULT_PROPERTIES = StaticCoreMessageListenerContainerProperties.builder()
             .shouldInterruptThreadsProcessingMessagesOnShutdown(true)
             .shouldProcessAnyExtraRetrievedMessagesOnShutdown(false)
-            .messageProcessingThreadNameFormat("test-%d")
             .messageProcessingShutdownTimeoutInSeconds(5)
             .messageResolverShutdownTimeoutInSeconds(5)
             .messageRetrieverShutdownTimeoutInSeconds(5)


### PR DESCRIPTION
This occurs if the broker thread had not been run before the container has
been requested to be shutdown. The result would be that the CompletableFuture
that indicates that the broker thread is finished would never be resolved
so we would sit here and wait forever.

This changes it to use the ExecutorService to shutdown all the threads.