### PR TITLE
refs #216: Adds a Kotlin DSL for managing the core library.

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "mailto:*"
+    },
+    {
+      "pattern": "https://coveralls.io.*"
     }
   ]
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
-import com.jashmore.JacocoCoverallsPlugin
-import com.jashmore.ReleasePlugin
-import com.jashmore.release
+import com.jashmore.gradle.JacocoCoverallsPlugin
+import com.jashmore.gradle.ReleasePlugin
+import com.jashmore.gradle.release
 
 plugins {
     java
@@ -20,10 +20,13 @@ allprojects {
 }
 
 subprojects {
+    val isKotlinProject = project.name.contains("kotlin")
     apply(plugin = "java-library")
-    apply(plugin = "com.github.spotbugs")
-    apply(plugin = "checkstyle")
     apply(plugin = "jacoco")
+    if (!isKotlinProject) {
+        apply(plugin = "com.github.spotbugs")
+        apply(plugin = "checkstyle")
+    }
 
     dependencies {
         // AWS
@@ -49,8 +52,10 @@ subprojects {
         testImplementation("ch.qos.logback:logback-core")
         testImplementation("ch.qos.logback:logback-classic")
 
-        // SpotBugs
-        spotbugs("com.github.spotbugs:spotbugs:4.0.6")
+        if (!isKotlinProject) {
+            // SpotBugs
+            spotbugs("com.github.spotbugs:spotbugs:4.0.6")
+        }
 
         constraints {
             // Jackson
@@ -93,20 +98,22 @@ subprojects {
         options.compilerArgs.addAll(setOf("-Xlint:all", "-Werror", "-Xlint:-processing", "-Xlint:-serial"))
     }
 
-    tasks.withType<Checkstyle> {
-        // Needed because this is generated code and I am not good enough with gradle to properly exclude these source files
-        // from only the checkstyleTest task
-        exclude("**com/jashmore/sqs/extensions/registry/model/*")
-    }
+    if (!isKotlinProject) {
+        tasks.withType<Checkstyle> {
+            // Needed because this is generated code and I am not good enough with gradle to properly exclude these source files
+            // from only the checkstyleTest task
+            exclude("**com/jashmore/sqs/extensions/registry/model/*")
+        }
 
-    checkstyle {
-        configFile = file("${project.rootDir}/configuration/checkstyle/google_6_18_checkstyle.xml")
-        maxWarnings = 0
-        maxErrors = 0
-    }
+        checkstyle {
+            configFile = file("${project.rootDir}/configuration/checkstyle/google_6_18_checkstyle.xml")
+            maxWarnings = 0
+            maxErrors = 0
+        }
 
-    spotbugs {
-        excludeFilter.set(file("${project.rootDir}/configuration/spotbugs/bugsExcludeFilter.xml"))
+        spotbugs {
+            excludeFilter.set(file("${project.rootDir}/configuration/spotbugs/bugsExcludeFilter.xml"))
+        }
     }
 
     tasks.withType<Test> {

--- a/buildSrc/src/main/kotlin/com/jashmore/gradle/JacocoCoverallsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/jashmore/gradle/JacocoCoverallsPlugin.kt
@@ -1,4 +1,4 @@
-package com.jashmore
+package com.jashmore.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/buildSrc/src/main/kotlin/com/jashmore/gradle/ReleasePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/jashmore/gradle/ReleasePlugin.kt
@@ -1,6 +1,6 @@
-package com.jashmore
+package com.jashmore.gradle
 
-import com.jashmore.utils.isSnapshotVersion
+import com.jashmore.gradle.utils.isSnapshotVersion
 import io.codearte.gradle.nexus.NexusStagingExtension
 import io.codearte.gradle.nexus.NexusStagingPlugin
 import org.gradle.api.Plugin

--- a/buildSrc/src/main/kotlin/com/jashmore/gradle/utils/VersionUtils.kt
+++ b/buildSrc/src/main/kotlin/com/jashmore/gradle/utils/VersionUtils.kt
@@ -1,3 +1,3 @@
-package com.jashmore.utils
+package com.jashmore.gradle.utils
 
 fun isSnapshotVersion(version: String) = version.endsWith("-SNAPSHOT")

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jashmore.gradle.jacoco-coveralls.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jashmore.gradle.jacoco-coveralls.properties
@@ -1,0 +1,1 @@
+implementation-class=com.jashmore.gradle.JacocoCoverallsPlugin

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jashmore.gradle.release.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/com.jashmore.gradle.release.properties
@@ -1,0 +1,1 @@
+implementation-class=com.jashmore.gradle.ReleasePlugin

--- a/doc/how-to-guides/core/core-how-to-add-aws-xray-tracing.md
+++ b/doc/how-to-guides/core/core-how-to-add-aws-xray-tracing.md
@@ -39,7 +39,7 @@ This will extract the tracing header from the SQS message and begin a Xray Segme
 ## Integration with AWS Xray Instrumentor
 
 If you want tracing information to be included when making client calls to AWS, you can add the
-[AWS Xray SDK V2 Instrumentor](https://github.com/aws/aws-xray-sdk-java/tree/master/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor) dependency. 
+[AWS Xray SDK V2 Instrumentor](https://github.com/aws/aws-xray-sdk-java/tree/master/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor) dependency.
 
 ```xml
     <dependency>
@@ -87,4 +87,3 @@ application, as all requests out to the SQS server will automatically be traced 
 maintains its own threads and does not start Xray segments, all calls out to SQS will throw exceptions due to a missing segment.
 The [XrayWrappedSqsAsyncClient](../../../extensions/aws-xray-extension/core/src/main/java/com/jashmore/sqs/extensions/xray/client/XrayWrappedSqsAsyncClient.java)
 protects against these errors by making sure there is always a segment present when making a call with the client by creating one for you.
-

--- a/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
+++ b/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
@@ -1,0 +1,58 @@
+# Core - Kotlin DSL
+
+As the [core](../../../core) library can be quite verbose to configure
+a [MessageListenerContainer](../../../api/src/main/java/com/jashmore/sqs/container/MessageListenerContainer.java),
+the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) tool can be used to easily set up a message listener.
+
+## Steps
+
+1. Depend on the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) module:
+
+    ```kotlin
+    implementation("com.jashmore:core-kotlin-dsl:${version}")
+    ```
+   
+   or
+    
+    ```xml
+    <dependency>
+        <groupId>com.jashmore</groupId>
+        <artifactId>core-kotlin-dsl</artifactId>
+        <version>${version}</version>
+    </dependency>
+    ```
+   
+1. Create the [MessageListenerContainer](../../../api/src/main/java/com/jashmore/sqs/container/MessageListenerContainer.java) using the Kotlin DSL
+
+    ```kotlin
+        val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            retriever = prefetchingMessageRetriever {
+                desiredPrefetchedMessages = 10
+                maxPrefetchedMessages = 20
+            }
+            processor = coreProcessor {
+                argumentResolverService = coreArgumentResolverService(objectMapper)
+                bean = MessageListener()
+                method = MessageListener::class.java.getMethod("listen", String::class.java)
+            }
+            broker = concurrentBroker {
+                concurrencyLevel = { 10 }
+                concurrencyPollingRate = { Duration.ofSeconds(30) }
+            }
+            resolver = batchingResolver {
+                bufferingSizeLimit = { 5 }
+                bufferingTime = { Duration.ofSeconds(2) }
+            }
+        }
+    ```
+
+1. Start the container as normal
+
+    ``kotlin
+        container.start()
+    ``
+
+Check out the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) for more details about the internals of this module and what you can use.
+
+## Example
+A full example of using the Kotlin DSL can be found in the [core-kotlin-example](../../../examples/core-kotlin-example/README.md).

--- a/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
+++ b/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
@@ -11,9 +11,9 @@ the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) tool can be used to e
     ```kotlin
     implementation("com.jashmore:core-kotlin-dsl:${version}")
     ```
-   
+
    or
-    
+
     ```xml
     <dependency>
         <groupId>com.jashmore</groupId>
@@ -21,7 +21,7 @@ the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) tool can be used to e
         <version>${version}</version>
     </dependency>
     ```
-   
+
 1. Create the [MessageListenerContainer](../../../api/src/main/java/com/jashmore/sqs/container/MessageListenerContainer.java) using the Kotlin DSL
 
     ```kotlin
@@ -48,11 +48,12 @@ the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) tool can be used to e
 
 1. Start the container as normal
 
-    ``kotlin
+    ```kotlin
         container.start()
-    ``
+    ```
 
 Check out the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) for more details about the internals of this module and what you can use.
 
 ## Example
+
 A full example of using the Kotlin DSL can be found in the [core-kotlin-example](../../../examples/core-kotlin-example/README.md).

--- a/doc/how-to-guides/spring/spring-how-to-add-aws-xray-tracing.md
+++ b/doc/how-to-guides/spring/spring-how-to-add-aws-xray-tracing.md
@@ -47,6 +47,7 @@ the [SqsListenerXrayConfiguration](../../../extensions/aws-xray-extension/spring
 builds the beans.
 
 ### Send internal library Xray traces
+
 By default, all the requests to receive messages and other internal calls by this library will not be sent to Xray. To override this you can define a
 custom [ClientSegmentMutator](../../../extensions/aws-xray-extension/core/src/main/java/com/jashmore/sqs/extensions/xray/client/ClientSegmentMutator.java).
 

--- a/examples/core-kotlin-example/README.md
+++ b/examples/core-kotlin-example/README.md
@@ -1,0 +1,10 @@
+# Core Kotlin Example
+
+This example shows the usage of the [core](../../core) module using the [Core Kotlin DSL](../../extensions/core-kotlin-dsl). It creates a
+message listener that will change the rate of concurrency each time period to show that we can dynamically scale the message listeners.
+
+## Usage
+
+```bash
+gradle runApp
+```

--- a/examples/core-kotlin-example/build.gradle.kts
+++ b/examples/core-kotlin-example/build.gradle.kts
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+description = "Example of using the Core library with the Kotlin DSL, this should be equivalent to the core-examples."
+
+plugins {
+    kotlin("jvm") version "1.3.72"
+}
+
+apply(plugin = "kotlin")
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(project(":java-dynamic-sqs-listener-core"))
+    implementation(project(":elasticmq-sqs-client"))
+    implementation(project(":core-kotlin-dsl"))
+    implementation("io.zipkin.brave:brave")
+    implementation("io.zipkin.brave:brave-context-slf4j")
+    implementation(project(":brave-message-processing-decorator"))
+    implementation("ch.qos.logback:logback-core")
+    implementation("ch.qos.logback:logback-classic")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+tasks.create<JavaExec>("runApp") {
+    classpath = sourceSets.main.get().runtimeClasspath
+
+    main = "com.jashmore.sqs.examples.KotlinConcurrentBrokerExample"
+}

--- a/examples/core-kotlin-example/src/main/kotlin/com/jashmore/sqs/examples/KotlinConcurrentBrokerExample.kt
+++ b/examples/core-kotlin-example/src/main/kotlin/com/jashmore/sqs/examples/KotlinConcurrentBrokerExample.kt
@@ -1,0 +1,120 @@
+@file:JvmName("KotlinConcurrentBrokerExample")
+package com.jashmore.sqs.examples
+
+import brave.Tracing
+import brave.context.slf4j.MDCScopeDecorator
+import brave.propagation.ThreadLocalCurrentTraceContext
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.jashmore.sqs.argument.messageid.MessageId
+import com.jashmore.sqs.argument.payload.Payload
+import com.jashmore.sqs.core.kotlin.dsl.argument.coreArgumentResolverService
+import com.jashmore.sqs.core.kotlin.dsl.container.coreMessageListener
+import com.jashmore.sqs.core.kotlin.dsl.utils.cached
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import com.jashmore.sqs.extensions.brave.decorator.BraveMessageProcessingDecorator
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
+
+private val log: Logger = LoggerFactory.getLogger("example")
+private val concurrencyLevelPeriod = Duration.ofSeconds(5)
+private const val concurrencyLimit = 10
+
+private val objectMapper = ObjectMapper().registerModule(KotlinModule())
+
+fun main() {
+    val sqsAsyncClient = ElasticMqSqsAsyncClient()
+    val queueUrl = sqsAsyncClient.createRandomQueue()
+            .get()
+            .queueUrl()
+
+    val tracing = Tracing.newBuilder()
+            .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+                    .addScopeDecorator(MDCScopeDecorator.get())
+                    .build()
+            )
+            .build()
+    tracing.isNoop = true
+
+    val container = coreMessageListener("core-example-container", sqsAsyncClient, queueUrl) {
+        retriever = prefetchingMessageRetriever {
+            desiredPrefetchedMessages = 10
+            maxPrefetchedMessages = 20
+        }
+        processor = coreProcessor {
+            argumentResolverService = coreArgumentResolverService(objectMapper)
+            bean = MessageListener()
+            method = MessageListener::class.java.getMethod("listen", Request::class.java, String::class.java)
+            decorators {
+                add(BraveMessageProcessingDecorator(tracing))
+            }
+        }
+        broker = concurrentBroker {
+            concurrencyLevel = cached(Duration.ofSeconds(10)) {
+                Random.nextInt(concurrencyLimit)
+            }
+            concurrencyPollingRate = { concurrencyLevelPeriod }
+            errorBackoffTime = { Duration.ofMinutes(500) }
+        }
+        resolver = batchingResolver {
+            bufferingSizeLimit = { 1 }
+            bufferingTime = { Duration.ofSeconds(5) }
+        }
+    }
+
+    container.start()
+
+    log.info("Started container")
+
+    CompletableFuture.runAsync {
+        messageProducer(sqsAsyncClient, queueUrl)
+    }
+}
+
+data class Request(val key: String)
+
+fun messageProducer(sqsAsyncClient: SqsAsyncClient, queueUrl: String) {
+    val count = AtomicInteger(0)
+    while (!Thread.currentThread().isInterrupted) {
+        try {
+            sqsAsyncClient.sendMessageBatch { batchBuilder ->
+                batchBuilder.queueUrl(queueUrl)
+                        .entries((0..9).map { index ->
+                            val request = Request("key_${count.getAndIncrement()}")
+                            SendMessageBatchRequestEntry.builder()
+                                    .id("$index")
+                                    .messageBody(objectMapper.writeValueAsString(request))
+                                    .build()
+                        })
+            }
+            log.info("Put 10 messages onto queue")
+            Thread.sleep(2000)
+        } catch (interruptedException: InterruptedException) {
+            log.info("Producer Thread has been interrupted")
+            break
+        }
+    }
+}
+
+class MessageListener {
+    private val concurrentMessagesBeingProcessed = AtomicInteger(0)
+
+    @Suppress("unused")
+    fun listen(@Payload request: Request, @MessageId messageId: String) {
+        try {
+            val concurrentMessages = concurrentMessagesBeingProcessed.incrementAndGet()
+            val processingTimeInMs = Random.nextInt(3000)
+            log.trace("Payload: {}, messageId: {}", request, messageId)
+            log.info("Message processing in {}ms. {} currently being processed concurrently", processingTimeInMs, concurrentMessages)
+            Thread.sleep(processingTimeInMs.toLong())
+        } finally {
+            concurrentMessagesBeingProcessed.decrementAndGet()
+        }
+    }
+}

--- a/examples/core-kotlin-example/src/main/resources/logback.xml
+++ b/examples/core-kotlin-example/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg %yellow(%mdc) %n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- We reduce the log messages from ElasticMQ, Akka and Netty to reduce the amount of unnecessary log messages being published -->
+    <logger name="org.elasticmq" level="OFF" />
+    <logger name="akka" level="OFF" />
+    <logger name="io.netty" level="ERROR" />
+
+    <logger name="com.jashmore" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/extensions/core-kotlin-dsl/build.gradle.kts
+++ b/extensions/core-kotlin-dsl/build.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+description = "Kotlin DSL for building the Core message listeners"
+
+plugins {
+    kotlin("jvm") version "1.3.72"
+}
+
+apply(plugin = "kotlin")
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    api(project(":java-dynamic-sqs-listener-core"))
+
+    testImplementation(project(":elasticmq-sqs-client"))
+    testImplementation(project(":expected-test-exception"))
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/MessageListenerContainerDsl.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/MessageListenerContainerDsl.kt
@@ -1,0 +1,153 @@
+package com.jashmore.sqs.core.kotlin.dsl
+
+import com.jashmore.sqs.core.kotlin.dsl.broker.ConcurrentMessageBrokerDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.processor.CoreMessageProcessorDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.resolver.BatchingMessageResolverDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.retriever.PrefetchingMessageRetrieverDslBuilder
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.argument.ArgumentResolverService
+import com.jashmore.sqs.broker.MessageBroker
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.core.kotlin.dsl.retriever.BatchingMessageRetrieverDslBuilder
+import com.jashmore.sqs.decorator.MessageProcessingDecorator
+import com.jashmore.sqs.processor.CoreMessageProcessor
+import com.jashmore.sqs.processor.MessageProcessor
+import com.jashmore.sqs.resolver.MessageResolver
+import com.jashmore.sqs.resolver.batching.BatchingMessageResolver
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.retriever.batching.BatchingMessageRetriever
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetriever
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+
+@DslMarker
+annotation class MessageListenerComponentDslMarker
+
+/**
+ * Used to build a single component of the [MessageListenerContainer].
+ *
+ * @param <T> the type of the component being built
+ */
+typealias MessageListenerComponentDslBuilder<T> = () -> T
+
+interface MessageRetrieverDslBuilder : MessageListenerComponentDslBuilder<MessageRetriever>
+
+interface MessageProcessorDslBuilder : MessageListenerComponentDslBuilder<MessageProcessor>
+
+interface ArgumentResolverServiceDslBuilder : MessageListenerComponentDslBuilder<ArgumentResolverService>
+
+interface MessageBrokerDslBuilder : MessageListenerComponentDslBuilder<MessageBroker>
+
+interface MessageResolverDslBuilder : MessageListenerComponentDslBuilder<MessageResolver>
+
+interface MessageProcessingDecoratorsDslBuilder: MessageListenerComponentDslBuilder<List<MessageProcessingDecorator>> {
+    /**
+     * Add a decorator to the chain of [MessageProcessingDecorator]s.
+     *
+     * @param decorator the decorator to add
+     */
+    fun add(decorator: MessageProcessingDecorator)
+}
+
+/**
+ * Abstract class for building a [MessageListenerContainer] that allows the implementer to use their own [MessageListenerContainer] implementation.
+ */
+@MessageListenerComponentDslMarker
+abstract class MessageListenerContainerBuilder(val identifier: String, val sqsAsyncClient: SqsAsyncClient, val queueProperties: QueueProperties) : MessageListenerComponentDslBuilder<MessageListenerContainer> {
+    var retriever: MessageRetrieverDslBuilder? = null
+    var processor: MessageProcessorDslBuilder? = null
+    var broker: MessageBrokerDslBuilder? = null
+    var resolver: MessageResolverDslBuilder? = null
+
+    /**
+     * Use the [ConcurrentMessageBroker] as the [MessageBroker] in this container.
+     *
+     * Usage:
+     * ```kotlin
+     * val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+     *     broker = concurrentBroker {
+     *        // configure here
+     *     }
+     *     // other configuration
+     * }
+     * ```
+     */
+    fun concurrentBroker(init: ConcurrentMessageBrokerDslBuilder.() -> Unit) = com.jashmore.sqs.core.kotlin.dsl.broker.concurrentBroker(init)
+
+    /**
+     * Use the [CoreMessageProcessor] as the [MessageProcessor] in this container.
+     *
+     * Usage:
+     * ```kotlin
+     * val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+     *     processor = coreProcessor {
+     *        // configure here
+     *     }
+     *     // other configuration
+     * }
+     * ```
+     *
+     * @param init the DSL function for configuring this processor
+     */
+    fun coreProcessor(init: CoreMessageProcessorDslBuilder.() -> Unit)
+            = com.jashmore.sqs.core.kotlin.dsl.processor.coreProcessor(identifier, sqsAsyncClient, queueProperties, init)
+
+    /**
+     * Use the [BatchingMessageRetriever] as the [MessageRetriever] for this container.
+     *
+     * Usage:
+     * ```kotlin
+     * val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+     *     retriever = batchingMessageRetriever {
+     *        // configure here
+     *     }
+     *     // other configuration
+     * }
+     * ```
+     *
+     * @param init the DSL function for configuring this resolver
+     */
+    fun batchingMessageRetriever(init: BatchingMessageRetrieverDslBuilder.() -> Unit)
+            = com.jashmore.sqs.core.kotlin.dsl.retriever.batchingMessageRetriever(sqsAsyncClient, queueProperties, init)
+
+    /**
+     * Use the [PrefetchingMessageRetriever] as the [MessageRetriever] for this container.
+     *
+     * Usage:
+     * ```kotlin
+     * val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+     *     retriever = prefetchingMessageRetriever {
+     *        // configure here
+     *     }
+     *     // other configuration
+     * }
+     * ```
+     *
+     * @param init the DSL function for configuring this resolver
+     */
+    fun prefetchingMessageRetriever(init: PrefetchingMessageRetrieverDslBuilder.() -> Unit)
+            = com.jashmore.sqs.core.kotlin.dsl.retriever.prefetchingMessageRetriever(sqsAsyncClient, queueProperties, init)
+
+    /**
+     * Use the [BatchingMessageResolver] as the [MessageResolver] for this container.
+     *
+     * Usage:
+     * ```kotlin
+     * val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+     *     resolver = batchingResolver {
+     *        // configure here
+     *     }
+     *     // other configuration
+     * }
+     * ```
+     *
+     * @param init the DSL function for configuring this resolver
+     */
+    fun batchingResolver(init: BatchingMessageResolverDslBuilder.() -> Unit)
+            = com.jashmore.sqs.core.kotlin.dsl.resolver.batchingResolver(sqsAsyncClient, queueProperties, init)
+}
+
+fun <T> initComponent(componentBuilder: T, init: T.() -> Unit): T {
+    componentBuilder.init()
+    return componentBuilder
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/CoreArgumentResolverServiceDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/CoreArgumentResolverServiceDslBuilder.kt
@@ -1,0 +1,37 @@
+package com.jashmore.sqs.core.kotlin.dsl.argument
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jashmore.sqs.argument.ArgumentResolverService
+import com.jashmore.sqs.argument.CoreArgumentResolverService
+import com.jashmore.sqs.argument.payload.mapper.JacksonPayloadMapper
+import com.jashmore.sqs.core.kotlin.dsl.ArgumentResolverServiceDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.processor.MessageProcessor
+
+/**
+ * [ArgumentResolverServiceDslBuilder] that constructs a [CoreArgumentResolverService] for the [MessageProcessor].
+ */
+@MessageListenerComponentDslMarker
+class CoreArgumentResolverServiceDslBuilder(private val objectMapper: ObjectMapper) : ArgumentResolverServiceDslBuilder {
+
+    override fun invoke(): ArgumentResolverService {
+        return CoreArgumentResolverService(
+                JacksonPayloadMapper(objectMapper),
+                objectMapper
+        )
+    }
+}
+
+/**
+ * Use the [CoreArgumentResolverService] as the [ArgumentResolverService] for the processor.
+ *
+ * Usage:
+ * ```kotlin
+ * val argumentResolverServiceBuilder = coreArgumentResolverService(ObjectMapper())
+ * ```
+ *
+ * @param init the DSL function for configuring this processor
+ */
+fun coreArgumentResolverService(objectMapper: ObjectMapper = ObjectMapper(), init: CoreArgumentResolverServiceDslBuilder.() -> Unit = { })
+        = initComponent(CoreArgumentResolverServiceDslBuilder(objectMapper), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/DelegatingArgumentResolverServiceDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/DelegatingArgumentResolverServiceDslBuilder.kt
@@ -1,0 +1,95 @@
+package com.jashmore.sqs.core.kotlin.dsl.argument
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jashmore.sqs.core.kotlin.dsl.ArgumentResolverServiceDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.argument.ArgumentResolver
+import com.jashmore.sqs.argument.ArgumentResolverService
+import com.jashmore.sqs.argument.DelegatingArgumentResolverService
+import com.jashmore.sqs.argument.attribute.MessageAttributeArgumentResolver
+import com.jashmore.sqs.argument.attribute.MessageSystemAttributeArgumentResolver
+import com.jashmore.sqs.argument.message.MessageArgumentResolver
+import com.jashmore.sqs.argument.messageid.MessageIdArgumentResolver
+import com.jashmore.sqs.argument.payload.PayloadArgumentResolver
+import com.jashmore.sqs.argument.payload.mapper.JacksonPayloadMapper
+import com.jashmore.sqs.processor.MessageProcessor
+
+/**
+ * [ArgumentResolverServiceDslBuilder] that constructs a [DelegatingArgumentResolverService] for the [MessageProcessor].
+ */
+@MessageListenerComponentDslMarker
+class DelegatingArgumentResolverServiceDslBuilder : ArgumentResolverServiceDslBuilder {
+    private val argumentResolvers = mutableListOf<ArgumentResolver<*>>()
+
+    /**
+     * Add a [PayloadArgumentResolver] that is able to de-serialize message bodies using Jackson.
+     *
+     * @param objectMapper the optional object mapper to use, otherwise a default is used
+     */
+    fun jacksonPayloadResolver(objectMapper: ObjectMapper = ObjectMapper()) {
+        add(PayloadArgumentResolver(JacksonPayloadMapper(objectMapper)))
+    }
+
+    /**
+     * Add a [MessageIdArgumentResolver] that is used to resolve the message ID.
+     */
+    fun messageIdResolver() {
+        add(MessageIdArgumentResolver())
+    }
+
+    /**
+     * Add a [MessageArgumentResolver] that is used to resolve the original message.
+     */
+    fun messageResolver() {
+        add(MessageArgumentResolver())
+    }
+
+    /**
+     * Add a [MessageAttributeArgumentResolver] that is used to resolve a message attribute using Jackson serialization.
+     *
+     * @param objectMapper the optional object mapper to use, otherwise a default is used
+     */
+    fun messageAttributeResolver(objectMapper: ObjectMapper = ObjectMapper()) {
+        add(MessageAttributeArgumentResolver(objectMapper))
+    }
+
+    /**
+     * Add a [MessageSystemAttributeArgumentResolver] that is used to resolve a message system attribute.
+
+     */
+    fun messageSystemAttributeResolver() {
+        add(MessageSystemAttributeArgumentResolver())
+    }
+
+    /**
+     * Add a specific [ArgumentResolver].
+     *
+     * @param argumentResolver the resolver to add
+     */
+    fun add(argumentResolver: ArgumentResolver<*>) {
+        argumentResolvers += argumentResolver
+    }
+
+    override fun invoke(): ArgumentResolverService {
+        return DelegatingArgumentResolverService(
+                argumentResolvers
+        )
+    }
+}
+
+/**
+ * Use the [DelegatingArgumentResolverService] as the [ArgumentResolverService] for this processor.
+ *
+ * Usage:
+ * ```kotlin
+ * val argumentResolverService = delegatingArgumentResolverService {
+ *     messageIdResolver()
+ *     // other argument resolvers here...
+ * }
+ * ```
+ *
+ * @param init the DSL function for configuring this processor
+ */
+fun delegatingArgumentResolverService(init: DelegatingArgumentResolverServiceDslBuilder.() -> Unit)
+        = initComponent(DelegatingArgumentResolverServiceDslBuilder(), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilder.kt
@@ -1,0 +1,71 @@
+package com.jashmore.sqs.core.kotlin.dsl.broker
+
+import com.jashmore.sqs.core.kotlin.dsl.MessageBrokerDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.broker.MessageBroker
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBroker
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import java.time.Duration
+
+/**
+ * [MessageBrokerDslBuilder] for building a [ConcurrentMessageBroker] for the [MessageListenerContainer].
+ */
+@MessageListenerComponentDslMarker
+class ConcurrentMessageBrokerDslBuilder : MessageBrokerDslBuilder {
+    /**
+     * Supplier for getting the number of messages that should be processed concurrently.
+     *
+     * Each time a new message is begun to be processed this supplier will be checked and therefore it should be optimised via caching
+     * or another method. This field may return different values each time it is checked and therefore the rate of concurrency can
+     * be dynamically changed during runtime.
+     *
+     * @see [ConcurrentMessageBrokerProperties.getConcurrencyLevel] for in-depth details about this field
+     */
+    var concurrencyLevel: (() -> Int)? = null
+
+    /**
+     * Supplier for getting how long the broker should wait before checking to see if the concurrency rate can be increased if it is
+     * already processing the concurrency level limit.
+     *
+     * @see [ConcurrentMessageBrokerProperties.getConcurrencyPollingRateInMilliseconds] for in-depth details about this field
+     */
+    var concurrencyPollingRate: (() -> Duration?) = { null }
+
+    /**
+     * The amount of time that the broker should backoff if there was an error.
+     *
+     * This is used to stop it constantly cycling errors and spamming the logs and hopefully the error fixes itself the next time it is
+     * attempted.
+     *
+     * @see [ConcurrentMessageBrokerProperties.getErrorBackoffTimeInMilliseconds] for in-depth details about this field
+     */
+    var errorBackoffTime: (() -> Duration?) = { null }
+
+    override fun invoke(): MessageBroker {
+        val actualConcurrencyLevel: () -> Int = concurrencyLevel ?: throw RequiredFieldException("concurrencyLevel", "ConcurrentMessageBroker")
+        return ConcurrentMessageBroker(
+                object : ConcurrentMessageBrokerProperties {
+                    override fun getErrorBackoffTimeInMilliseconds(): Long? = errorBackoffTime()?.toMillis()
+
+                    override fun getConcurrencyLevel(): Int = actualConcurrencyLevel()
+
+                    override fun getConcurrencyPollingRateInMilliseconds(): Long? = concurrencyPollingRate()?.toMillis()
+                }
+        )
+    }
+}
+
+/**
+ * Create a [ConcurrentMessageBroker] using a Kotlin DSL format.
+ *
+ * Usage:
+ * ```kotlin
+ * val broker = concurrentBroker {
+ *     // configure here
+ * }
+ * ```
+ */
+fun concurrentBroker(init: ConcurrentMessageBrokerDslBuilder.() -> Unit) = initComponent(ConcurrentMessageBrokerDslBuilder(), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilder.kt
@@ -1,0 +1,179 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.core.kotlin.dsl.MessageBrokerDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerContainerBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageProcessorDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageResolverDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageRetrieverDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.broker.MessageBroker
+import com.jashmore.sqs.container.CoreMessageListenerContainer
+import com.jashmore.sqs.container.CoreMessageListenerContainerProperties
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.resolver.MessageResolver
+import com.jashmore.sqs.retriever.MessageRetriever
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+import java.util.function.Supplier
+
+/**
+ * [MessageListenerContainerBuilder] that will construct a [MessageListenerContainer] for usage in this container.
+ */
+@MessageListenerComponentDslMarker
+class CoreMessageListenerContainerBuilder(identifier: String, sqsAsyncClient: SqsAsyncClient, queueProperties: QueueProperties)
+    : MessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties) {
+    private var shutdownBuilder: ShutdownBuilder? = null
+
+    /**
+     * Configure the shutdown properties for this container.
+     */
+    fun shutdown(init: ShutdownBuilder.() -> Unit) {
+        shutdownBuilder = initComponent(ShutdownBuilder(), init)
+    }
+
+    override fun invoke(): MessageListenerContainer {
+        val brokerBuilder: MessageBrokerDslBuilder = broker ?: throw RequiredFieldException("broker", "CoreMessageListenerContainer")
+        val retrieverBuilder: MessageRetrieverDslBuilder = retriever ?: throw RequiredFieldException("retriever", "CoreMessageListenerContainer")
+        val processorBuilder: MessageProcessorDslBuilder = processor ?: throw RequiredFieldException("processor", "CoreMessageListenerContainer")
+        val resolverBuilder: MessageResolverDslBuilder = resolver ?: throw RequiredFieldException("resolver", "CoreMessageListenerContainer")
+        val shutdown = shutdownBuilder
+        if (shutdown != null) {
+            return CoreMessageListenerContainer(identifier,
+                    Supplier(brokerBuilder),
+                    Supplier(retrieverBuilder),
+                    Supplier(processorBuilder),
+                    Supplier(resolverBuilder),
+                    object : CoreMessageListenerContainerProperties {
+                        override fun getMessageRetrieverShutdownTimeoutInSeconds(): Int? = shutdown.messageRetrieverShutdownTimeout?.seconds?.toInt()
+
+                        override fun shouldInterruptThreadsProcessingMessagesOnShutdown(): Boolean? = shutdown.shouldInterruptThreadsProcessingMessages
+
+                        override fun getMessageResolverShutdownTimeoutInSeconds(): Int? = shutdown.messageResolverShutdownTimeout?.seconds?.toInt()
+
+                        override fun shouldProcessAnyExtraRetrievedMessagesOnShutdown(): Boolean? = shutdown.shouldProcessAnyExtraRetrievedMessages
+
+                        override fun getMessageProcessingShutdownTimeoutInSeconds(): Int? = shutdown.messageProcessingShutdownTimeout?.seconds?.toInt()
+                    }
+            )
+        } else {
+            return CoreMessageListenerContainer(identifier,
+                    Supplier(brokerBuilder),
+                    Supplier(retrieverBuilder),
+                    Supplier(processorBuilder),
+                    Supplier(resolverBuilder)
+            )
+        }
+    }
+}
+
+@MessageListenerComponentDslMarker
+class ShutdownBuilder {
+    /**
+     * Set whether any extra messages that may have been internally stored in the [MessageRetriever] should be processed before shutting down.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldProcessAnyExtraRetrievedMessagesOnShutdown] for more details about this field
+     */
+    var shouldProcessAnyExtraRetrievedMessages: Boolean? = null
+    /**
+     * Set whether the message processing threads should be interrupted when a shutdown is requested.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldInterruptThreadsProcessingMessagesOnShutdown] for more details about this field
+     */
+    var shouldInterruptThreadsProcessingMessages: Boolean? = null
+
+    /**
+     * Set the timeout for how long to wait for the message processing threads to finish.
+     *
+     * @see [CoreMessageListenerContainerProperties.getMessageProcessingShutdownTimeoutInSeconds] for more details about this field
+     */
+    var messageProcessingShutdownTimeout: Duration? = null
+    /**
+     * Set the timeout for how long to wait for the [MessageRetriever] background thread to finish.
+     *
+     * @see [CoreMessageListenerContainerProperties.getMessageRetrieverShutdownTimeoutInSeconds] for more details about this field
+     */
+    var messageRetrieverShutdownTimeout: Duration? = null
+    /**
+     * Set the timeout for how to wait for the [MessageResolver] background thread to finish.
+     *
+     * @see [CoreMessageListenerContainerProperties.getMessageResolverShutdownTimeoutInSeconds] for more details about this field
+     */
+    var messageResolverShutdownTimeout: Duration? = null
+    /**
+     * Set the timeout for how to wait for the [MessageBroker] background thread to finish.
+     *
+     * Note that if the [ShutdownBuilder.shouldProcessAnyExtraRetrievedMessages] is true and there are extra messages to process, this timeout will
+     * be used twice.
+     *
+     * @see [CoreMessageListenerContainerProperties.getMessageBrokerShutdownTimeoutInSeconds] for more details about this field
+     */
+    var messageBrokerShutdownTimeout: Duration? = null
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = coreMessageListener("identifier", sqsAsyncClient, "someUrl") {
+ *      processor = coreMessageProcessor {
+ *           // configure this processor...
+ *      }
+ *
+ *      retriever = prefetchingMessageRetriever {
+ *          // configure this retriever...
+ *      }
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier     the identifier that uniquely identifies this container
+ * @param sqsAsyncClient the client for communicating with the SQS server
+ * @param queueUrl       the URL of the SQS queue to listen to
+ * @param init           the function to configure this container
+ */
+fun coreMessageListener(identifier: String,
+                        sqsAsyncClient: SqsAsyncClient,
+                        queueUrl: String,
+                        init: CoreMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return coreMessageListener(identifier, sqsAsyncClient, QueueProperties.builder().queueUrl(queueUrl).build(), init)
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = coreMessageListener("identifier", sqsAsyncClient, QueueProperties.builder().queueUrl("url").build()) {
+ *      processor = coreMessageProcessor {
+ *           // configure this processor...
+ *      }
+ *
+ *      retriever = prefetchingMessageRetriever {
+ *          // configure this retriever...
+ *      }
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier      the identifier that uniquely identifies this container
+ * @param sqsAsyncClient  the client for communicating with the SQS server
+ * @param queueProperties details about the queue that is being listened to
+ * @param init            the function to configure this container
+ */
+fun coreMessageListener(identifier: String,
+                        sqsAsyncClient: SqsAsyncClient,
+                        queueProperties: QueueProperties,
+                        init: CoreMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+
+    val listener = CoreMessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties)
+    listener.init()
+    return listener.invoke()
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/decorators/CoreMessageProcessingDecoratorsDslDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/decorators/CoreMessageProcessingDecoratorsDslDslBuilder.kt
@@ -1,0 +1,21 @@
+package com.jashmore.sqs.core.kotlin.dsl.decorators
+
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageProcessingDecoratorsDslBuilder
+import com.jashmore.sqs.decorator.MessageProcessingDecorator
+
+/**
+ * Core [MessageProcessingDecoratorsDslBuilder] that just simply adds all the decorators to a list.
+ */
+@MessageListenerComponentDslMarker
+class CoreMessageProcessingDecoratorsDslDslBuilder : MessageProcessingDecoratorsDslBuilder {
+    private val decorators = mutableListOf<MessageProcessingDecorator>()
+
+    override fun add(decorator: MessageProcessingDecorator) {
+        decorators.add(decorator)
+    }
+
+    override fun invoke(): List<MessageProcessingDecorator> {
+        return decorators.toList()
+    }
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/processor/CoreMessageProcessorDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/processor/CoreMessageProcessorDslBuilder.kt
@@ -1,0 +1,79 @@
+package com.jashmore.sqs.core.kotlin.dsl.processor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.argument.ArgumentResolverService
+import com.jashmore.sqs.argument.CoreArgumentResolverService
+import com.jashmore.sqs.core.kotlin.dsl.ArgumentResolverServiceDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageProcessingDecoratorsDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.MessageProcessorDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.argument.CoreArgumentResolverServiceDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.decorators.CoreMessageProcessingDecoratorsDslDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.decorator.MessageProcessingDecorator
+import com.jashmore.sqs.processor.CoreMessageProcessor
+import com.jashmore.sqs.processor.DecoratingMessageProcessor
+import com.jashmore.sqs.processor.MessageProcessor
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.lang.reflect.Method
+
+/**
+ * [MessageProcessorDslBuilder] that will construct a [CoreMessageProcessor] for usage in this container.
+ */
+@MessageListenerComponentDslMarker
+class CoreMessageProcessorDslBuilder(private val listenerIdentifier: String,
+                                     private val sqsAsyncClient: SqsAsyncClient,
+                                     private val queueProperties: QueueProperties) : MessageProcessorDslBuilder {
+    /**
+     * The builder for instantiating the [ArgumentResolverService] to be used.
+     *
+     * If this is not supplied, a default [CoreArgumentResolverService] will be used which configures the core argument resolvers.
+     */
+    var argumentResolverService: ArgumentResolverServiceDslBuilder = CoreArgumentResolverServiceDslBuilder(ObjectMapper())
+
+    /**
+     * The object instance that will execute the message listener method.
+     */
+    var bean: Any? = null
+
+    /**
+     * The method that will invoke the message listener logic.
+     */
+    var method: Method? = null
+
+    private var decorators: MessageProcessingDecoratorsDslBuilder = CoreMessageProcessingDecoratorsDslDslBuilder()
+
+    /**
+     * Add [MessageProcessingDecorator]s to the [MessageProcessor].
+     *
+     * @param init the kotlin DSL function for adding decorators
+     */
+    fun decorators(init: MessageProcessingDecoratorsDslBuilder.() -> Unit) {
+        decorators.init()
+    }
+
+    override fun invoke(): MessageProcessor {
+        val delegate = CoreMessageProcessor(
+                argumentResolverService.invoke(),
+                queueProperties,
+                sqsAsyncClient,
+                method ?: throw RequiredFieldException("method", "CoreMessageProcessor"),
+                bean ?: throw RequiredFieldException("bean", "CoreMessageProcessor")
+        )
+        val messageProcessingDecorators = decorators()
+        if (messageProcessingDecorators.isEmpty()) {
+            return delegate
+        }
+        return DecoratingMessageProcessor(
+                listenerIdentifier,
+                queueProperties,
+                messageProcessingDecorators,
+                delegate
+        )
+    }
+}
+
+fun coreProcessor(identifier: String, sqsAsyncClient: SqsAsyncClient, queueProperties: QueueProperties, init: CoreMessageProcessorDslBuilder.() -> Unit)
+        = initComponent(CoreMessageProcessorDslBuilder(identifier, sqsAsyncClient, queueProperties), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/resolver/BatchingMessageResolverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/resolver/BatchingMessageResolverDslBuilder.kt
@@ -1,0 +1,49 @@
+package com.jashmore.sqs.core.kotlin.dsl.resolver
+
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageResolverDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.resolver.MessageResolver
+import com.jashmore.sqs.resolver.batching.BatchingMessageResolver
+import com.jashmore.sqs.resolver.batching.BatchingMessageResolverProperties
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+
+/**
+ * [MessageResolverDslBuilder] that will construct a [BatchingMessageResolver] for usage in this container.
+ */
+@MessageListenerComponentDslMarker
+class BatchingMessageResolverDslBuilder(private val sqsAsyncClient: SqsAsyncClient, private val queueProperties: QueueProperties) : MessageResolverDslBuilder {
+    /**
+     * Supplier for getting the buffer size for resolving the messages.
+     *
+     * @see [BatchingMessageResolver.getBatchSize] for in-depth details about this field
+     */
+    var bufferingSizeLimit: (() -> Int)? = null
+    /**
+     * Supplier for getting the amount of time to wait for the buffer to fill to the limit before sending out any currently buffered messages.
+     *
+     * @see [BatchingMessageResolver.getBufferingTimeInMs] for in-depth details about this field
+     */
+    var bufferingTime: (() -> Duration)? = null
+
+    override fun invoke(): MessageResolver {
+        val actualBufferingSizeLimit: () -> Int = bufferingSizeLimit ?: throw RequiredFieldException("bufferingSizeLimit", "BatchingMessageResolver")
+        val actualBufferingTime: () -> Duration = bufferingTime ?: throw RequiredFieldException("bufferingTime", "BatchingMessageResolver")
+
+        return BatchingMessageResolver(
+                queueProperties,
+                sqsAsyncClient,
+                object : BatchingMessageResolverProperties {
+                    override fun getBufferingSizeLimit(): Int = actualBufferingSizeLimit()
+
+                    override fun getBufferingTimeInMs(): Long = actualBufferingTime().toMillis()
+                }
+        )
+    }
+}
+
+fun batchingResolver(sqsAsyncClient: SqsAsyncClient, queueProperties: QueueProperties, init: BatchingMessageResolverDslBuilder.() -> Unit)
+        = initComponent(BatchingMessageResolverDslBuilder(sqsAsyncClient, queueProperties), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilder.kt
@@ -1,0 +1,73 @@
+package com.jashmore.sqs.core.kotlin.dsl.retriever
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageRetrieverDslBuilder
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.retriever.batching.BatchingMessageRetriever
+import com.jashmore.sqs.retriever.batching.BatchingMessageRetrieverProperties
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetriever
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetrieverProperties
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+
+
+/**
+ * The [MessageRetrieverDslBuilder] hat will construct a [PrefetchingMessageRetriever] for usage in this container.
+ */
+@MessageListenerComponentDslMarker
+class BatchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsyncClient,
+                                         private val queueProperties: QueueProperties) : MessageRetrieverDslBuilder {
+    /**
+     * The batch size for the number of messages to receive at once
+     *
+     * @see BatchingMessageRetrieverProperties.getBatchSize for more details about this field
+     */
+    var batchSize: (() -> Int)? = null
+
+    /**
+     * The maximum amount of time to wait for the number of messages requested to reach the [BatchingMessageRetrieverDslBuilder.batchSize].
+     *
+     * @see BatchingMessageRetrieverProperties.getBatchingPeriodInMs for more details about this field
+     */
+    var batchingPeriod: (() -> Duration)? = null
+
+    /**
+     * Function for obtaining the visibility timeout for the message being retrieved.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeoutInSeconds for more details about this field
+     */
+    var messageVisibility: (() -> Duration?)? = null
+
+    /**
+     * Function for obtaining the error backoff time if there is an error retrieving messages.
+     *
+     * This helps stop the application constantly throwing errors if there was a problem.
+     */
+    var errorBackoffTime: (() -> Duration?)? = null
+
+    override fun invoke(): MessageRetriever {
+        val actualBatchSize: () -> Int = batchSize ?: throw RequiredFieldException("batchSize", "BatchingMessageRetriever")
+        val actualBatchingPeriod: () -> Duration = batchingPeriod ?: throw RequiredFieldException("batchingPeriod", "BatchingMessageRetriever")
+        val actualMessageVisibility: () -> Duration? = messageVisibility ?: { null }
+        val actualErrorBackoffTime: () -> Duration? = errorBackoffTime ?: { null }
+
+        return BatchingMessageRetriever(
+                queueProperties,
+                sqsAsyncClient,
+                object : BatchingMessageRetrieverProperties {
+                    override fun getBatchSize(): Int = actualBatchSize()
+
+                    override fun getBatchingPeriodInMs(): Long = actualBatchingPeriod().toMillis()
+
+                    override fun getMessageVisibilityTimeoutInSeconds(): Int? = actualMessageVisibility()?.seconds?.toInt()
+
+                    override fun getErrorBackoffTimeInMilliseconds(): Long? = actualErrorBackoffTime()?.toMillis()
+                }
+        )
+    }
+}
+
+fun batchingMessageRetriever(sqsAsyncClient: SqsAsyncClient, queueProperties: QueueProperties, init: BatchingMessageRetrieverDslBuilder.() -> Unit) = initComponent(BatchingMessageRetrieverDslBuilder(sqsAsyncClient, queueProperties), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilder.kt
@@ -1,0 +1,71 @@
+package com.jashmore.sqs.core.kotlin.dsl.retriever
+
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.MessageRetrieverDslBuilder
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.core.kotlin.dsl.initComponent
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetriever
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetrieverProperties
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+
+/**
+ * The [MessageRetrieverDslBuilder] hat will construct a [PrefetchingMessageRetriever] for usage in this container.
+ */
+@MessageListenerComponentDslMarker
+class PrefetchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsyncClient,
+                                            private val queueProperties: QueueProperties) : MessageRetrieverDslBuilder {
+    /**
+     * The desired messages to be prefetched.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getDesiredMinPrefetchedMessages for more details about this field
+     */
+    var desiredPrefetchedMessages: Int? = null
+
+    /**
+     * The maximum numbers that can be prefetched, must be less than [PrefetchingMessageRetrieverDslBuilder.desiredPrefetchedMessages].
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMaxPrefetchedMessages for more details about this field
+     */
+    var maxPrefetchedMessages: Int? = null
+
+    /**
+     * Function for obtaining the visibility timeout for the message being retrieved.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeoutInSeconds for more details about this field
+     */
+    var messageVisibility: (() -> Duration?)? = null
+
+    /**
+     * Function for obtaining the error backoff time if there is an error retrieving messages.
+     *
+     * This helps stop the application constantly throwing errors if there was a problem.
+     */
+    var errorBackoffTime: (() -> Duration?)? = null
+
+    override fun invoke(): MessageRetriever {
+        val actualDesiredPrefetchedMessages: Int = desiredPrefetchedMessages ?: throw RequiredFieldException("desiredPrefetchedMessages", "PrefetchingMessageRetriever")
+        val actualMaxPrefetched: Int = maxPrefetchedMessages ?: throw RequiredFieldException("maxPrefetchedMessages", "PrefetchingMessageRetriever")
+        val actualMessageVisibility: () -> Duration? = messageVisibility ?: { null }
+        val actualErrorBackoffTime: () -> Duration? = errorBackoffTime ?: { null }
+
+        return PrefetchingMessageRetriever(
+                sqsAsyncClient,
+                queueProperties,
+                object : PrefetchingMessageRetrieverProperties {
+                    override fun getDesiredMinPrefetchedMessages(): Int = actualDesiredPrefetchedMessages
+
+                    override fun getMaxPrefetchedMessages(): Int = actualMaxPrefetched
+
+                    override fun getMessageVisibilityTimeoutInSeconds(): Int? = actualMessageVisibility()?.seconds?.toInt()
+
+                    override fun getErrorBackoffTimeInMilliseconds(): Int? = actualErrorBackoffTime()?.toMillis()?.toInt()
+                }
+        )
+    }
+}
+
+fun prefetchingMessageRetriever(sqsAsyncClient: SqsAsyncClient, queueProperties: QueueProperties, init: PrefetchingMessageRetrieverDslBuilder.() -> Unit)
+        = initComponent(PrefetchingMessageRetrieverDslBuilder(sqsAsyncClient, queueProperties), init)

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/CachingDslUtils.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/CachingDslUtils.kt
@@ -1,0 +1,25 @@
+package com.jashmore.sqs.core.kotlin.dsl.utils
+
+import java.time.Duration
+
+/**
+ * Cached implementations that works when the usage of it is single threaded.
+ *
+ * If this cached function is used in multiple threads, it may result in multiple calls to get the current value at the same time.
+ *
+ * @param timeout  the amount of time that a value should be cached for
+ * @param delegate the delegate method to get the value when the cache has expired
+ * @param <T> the type of the value to cache
+ */
+fun <T> cached(timeout: Duration, delegate: () -> T): () -> T {
+    var timeOfLastCachedValueInMs: Long = System.currentTimeMillis() - timeout.toMillis() - 1
+    var cachedValue: T? = null
+
+    return {
+        if (timeOfLastCachedValueInMs + timeout.toMillis() < System.currentTimeMillis()) {
+            cachedValue = delegate()
+            timeOfLastCachedValueInMs = System.currentTimeMillis()
+        }
+        cachedValue!!
+    }
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/RequiredFieldException.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/RequiredFieldException.kt
@@ -1,0 +1,8 @@
+package com.jashmore.sqs.core.kotlin.dsl.utils
+
+/**
+ * Exception thrown if a field is required for the specific component construction.
+ *
+ * This is required as the compile time checks for required fields in Kotlin DSL isn't quite there yet.
+ */
+class RequiredFieldException(fieldName: String, componentName: String) : RuntimeException("$fieldName is required for $componentName")

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/DelegatingArgumentResolverServiceDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/argument/DelegatingArgumentResolverServiceDslBuilderTest.kt
@@ -1,0 +1,220 @@
+package com.jashmore.sqs.core.kotlin.dsl.argument
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.argument.MethodParameter
+import com.jashmore.sqs.argument.attribute.MessageAttribute
+import com.jashmore.sqs.argument.attribute.MessageSystemAttribute
+import com.jashmore.sqs.argument.attribute.MessageSystemAttributeArgumentResolver
+import com.jashmore.sqs.argument.message.MessageArgumentResolver
+import com.jashmore.sqs.argument.messageid.MessageId
+import com.jashmore.sqs.argument.messageid.MessageIdArgumentResolver
+import com.jashmore.sqs.argument.payload.Payload
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.mock
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
+import java.lang.reflect.Method
+import java.lang.reflect.Parameter
+
+class DelegatingArgumentResolverServiceDslBuilderTest {
+    private val objectMapper = ObjectMapper().registerModule(KotlinModule())
+    private val queueProperties = QueueProperties.builder().queueUrl("url").build()
+    private val method: Method = DelegatingArgumentResolverServiceDslBuilderTest::class.java.getMethod("myMethod",
+            User::class.java, String::class.java, User::class.java, String::class.java, Message::class.java)
+
+    @Test
+    fun `custom ArgumentResolver can be included`() {
+        // arrange
+        val messageIdArgumentResolver = MessageIdArgumentResolver()
+
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            add(messageIdArgumentResolver)
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+
+        // assert
+        assertThat(argumentResolverService.getArgumentResolver(MethodParameterRecord(method, parameterIndex = 1))).isSameAs(messageIdArgumentResolver)
+    }
+
+    @Test
+    fun `messageIdResolver can be be included`() {
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            messageIdResolver()
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+
+        // assert
+        assertThat(argumentResolverService.getArgumentResolver(MethodParameterRecord(method, parameterIndex = 1)))
+                .isInstanceOf(MessageIdArgumentResolver::class.java)
+    }
+
+    @Test
+    fun `messageResolver can be be included`() {
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            messageResolver()
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+
+        // assert
+        assertThat(argumentResolverService.getArgumentResolver(MethodParameterRecord(method, parameterIndex = 4)))
+                .isInstanceOf(MessageArgumentResolver::class.java)
+    }
+
+    @Test
+    fun `jacksonPayloadResolver can be included without a custom ObjectMapper`() {
+        // arrange
+        val message = Message.builder().body(objectMapper.writeValueAsString(User("name"))).build()
+        val methodParameter = MethodParameterRecord(method, parameterIndex = 0)
+
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            jacksonPayloadResolver()
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+        val argumentResolver = argumentResolverService.getArgumentResolver(methodParameter)
+        val argument = argumentResolver.resolveArgumentForParameter(queueProperties, methodParameter, message)
+
+        // assert
+        assertThat(argument).isEqualTo(User("name"))
+    }
+
+    @Test
+    fun `jacksonPayloadResolver can be included with a custom ObjectMapper`() {
+        // arrange
+        val message = Message.builder().body(objectMapper.writeValueAsString(User("name"))).build()
+        val mockObjectMapper = mock(ObjectMapper::class.java)
+        whenever(mockObjectMapper.readValue(anyString(), any(Class::class.java))).thenReturn(User("my-username"))
+
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            jacksonPayloadResolver(mockObjectMapper)
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+        val methodParameter = MethodParameterRecord(method, parameterIndex = 0)
+        val argumentResolver = argumentResolverService.getArgumentResolver(methodParameter)
+        val argument = argumentResolver.resolveArgumentForParameter(queueProperties, methodParameter, message)
+
+        // assert
+        assertThat(argument).isEqualTo(User("my-username"))
+    }
+
+    @Test
+    fun `messageAttributeResolver can be be included without a custom ObjectMapper`() {
+        // arrange
+        val message = Message.builder()
+                .messageAttributes(mapOf("user" to MessageAttributeValue.builder()
+                        .dataType("String")
+                        .stringValue(objectMapper.writeValueAsString(User("name")))
+                        .build()
+                ))
+                .body("body")
+                .build()
+        val mockObjectMapper = mock(ObjectMapper::class.java)
+        val methodParameter = MethodParameterRecord(method, parameterIndex = 2)
+        whenever(mockObjectMapper.readValue(anyString(), any(Class::class.java))).thenReturn(User("my-username"))
+
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            messageAttributeResolver(mockObjectMapper)
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+        val argumentResolver = argumentResolverService.getArgumentResolver(methodParameter)
+        val argument = argumentResolver.resolveArgumentForParameter(queueProperties, methodParameter, message)
+
+        // assert
+        assertThat(argument).isEqualTo(User("my-username"))
+    }
+
+    @Test
+    fun `messageAttributeResolver can be be included with a custom ObjectMapper`() {
+        // arrange
+        val message = Message.builder()
+                .messageAttributes(mapOf("user" to MessageAttributeValue.builder()
+                        .dataType("String")
+                        .stringValue(objectMapper.writeValueAsString(User("name")))
+                        .build()
+                ))
+                .body("body")
+                .build()
+        val methodParameter = MethodParameterRecord(method, parameterIndex = 2)
+
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            messageAttributeResolver()
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+        val argumentResolver = argumentResolverService.getArgumentResolver(methodParameter)
+        val argument = argumentResolver.resolveArgumentForParameter(queueProperties, methodParameter, message)
+
+        // assert
+        assertThat(argument).isEqualTo(User("name"))
+    }
+
+    @Test
+    fun `messageSystemAttributeResolver can be be included`() {
+        // act
+        val argumentResolverServiceDslBuilder = delegatingArgumentResolverService {
+            messageSystemAttributeResolver()
+        }
+        val argumentResolverService = argumentResolverServiceDslBuilder()
+
+        // assert
+        assertThat(argumentResolverService.getArgumentResolver(MethodParameterRecord(method, parameterIndex = 3)))
+                .isInstanceOf(MessageSystemAttributeArgumentResolver::class.java)
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun myMethod(@Payload payload: User,
+                 @MessageId id: String,
+                 @MessageAttribute("user") userAttribute: User,
+                 @MessageSystemAttribute(MessageSystemAttributeName.AWS_TRACE_HEADER) systemAttribute: String,
+                 message: Message) {
+
+    }
+
+    private class MethodParameterRecord(private val method: Method, private val parameterIndex: Int) : MethodParameter {
+        override fun getParameter(): Parameter = method.parameters[parameterIndex]
+
+        override fun getMethod(): Method = method
+
+        override fun getParameterIndex(): Int = parameterIndex
+    }
+
+    @Suppress("unused")
+    class User {
+        var username: String?
+
+        constructor() {
+            this.username = null
+        }
+
+        constructor(username: String) {
+            this.username = username
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as User
+
+            if (username != other.username) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return username?.hashCode() ?: 0
+        }
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilderTest.kt
@@ -1,0 +1,76 @@
+package com.jashmore.sqs.core.kotlin.dsl.broker
+
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sqs.model.Message
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.Function
+import java.util.function.Supplier
+
+class ConcurrentMessageBrokerDslBuilderTest {
+
+    @Test
+    fun `no currency level supplier set will throw exception`() {
+        // act
+        val exception = assertThrows(RequiredFieldException::class.java) {
+            concurrentBroker {
+
+            }()
+        }
+
+        // assert
+        assertThat(exception).hasMessage("concurrencyLevel is required for ConcurrentMessageBroker")
+    }
+
+    @Test
+    fun `will allow processing of messages concurrently`() {
+        // arrange
+        val staticConcurrencyLevel = 5
+        val latch = CountDownLatch(staticConcurrencyLevel)
+
+        // act
+        val broker = concurrentBroker {
+            concurrencyLevel = { staticConcurrencyLevel }
+        }()
+        val executorService = Executors.newSingleThreadExecutor()
+        try {
+            CompletableFuture.runAsync(Runnable {
+                broker.processMessages(
+                        Executors.newCachedThreadPool(),
+                        Supplier { CompletableFuture.completedFuture(Message.builder().build()) },
+                        processingMessageWillBlockUntilInterrupted(latch)
+                )
+            }, executorService)
+
+
+            // assert
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+        } finally {
+            executorService.shutdownNow()
+        }
+    }
+
+    private fun processingMessageWillBlockUntilInterrupted(messageProcessingLatch: CountDownLatch): Function<Message?, CompletableFuture<*>?>? {
+        return processingMessageWillBlockUntilInterrupted(messageProcessingLatch, Runnable {})
+    }
+
+    private fun processingMessageWillBlockUntilInterrupted(messageProcessingLatch: CountDownLatch?,
+                                                           runnableCalledOnMessageProcessing: Runnable): Function<Message?, CompletableFuture<*>?>? {
+        return Function {
+            CompletableFuture.runAsync(Runnable {
+                runnableCalledOnMessageProcessing.run()
+                messageProcessingLatch?.countDown()
+                try {
+                    Thread.sleep(Long.MAX_VALUE)
+                } catch (interruptedException: InterruptedException) {
+                    //expected
+                }
+            }, Executors.newCachedThreadPool())
+        }
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilderTest.kt
@@ -1,0 +1,130 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class CoreMessageListenerContainerBuilderTest {
+
+    var container: MessageListenerContainer? = null
+
+    @AfterEach
+    internal fun tearDown() {
+        container?.stop()
+    }
+
+    @Test
+    fun `minimal configuration`() {
+        // arrange
+        val sqsAsyncClient = ElasticMqSqsAsyncClient()
+        val queueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+
+        // act
+        container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            processor = coreProcessor {
+                bean = MessageListener(countDownLatch)
+                method = MessageListener::class.java.getMethod("processMessage")
+            }
+            retriever = prefetchingMessageRetriever {
+                desiredPrefetchedMessages = 1
+                maxPrefetchedMessages = 2
+            }
+            resolver = batchingResolver {
+                bufferingSizeLimit = { 1 }
+                bufferingTime = { Duration.ofSeconds(1) }
+            }
+            broker = concurrentBroker {
+                concurrencyLevel = { 1 }
+            }
+        }
+        container?.start()
+        sqsAsyncClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }
+
+        // assert
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+
+    @Test
+    fun `can configure batching message retriever`() {
+        // arrange
+        val sqsAsyncClient = ElasticMqSqsAsyncClient()
+        val queueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+
+        // act
+        container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            processor = coreProcessor {
+                bean = MessageListener(countDownLatch)
+                method = MessageListener::class.java.getMethod("processMessage")
+            }
+            retriever = batchingMessageRetriever {
+                batchSize = { 1 }
+                batchingPeriod = { Duration.ofSeconds(5) }
+            }
+            resolver = batchingResolver {
+                bufferingSizeLimit = { 1 }
+                bufferingTime = { Duration.ofSeconds(1) }
+            }
+            broker = concurrentBroker {
+                concurrencyLevel = { 1 }
+            }
+        }
+        container?.start()
+        sqsAsyncClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }
+
+        // assert
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun `can configure shutdown configuration for container`() {
+        // arrange
+        val sqsAsyncClient = ElasticMqSqsAsyncClient()
+        val queueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+
+        // act
+         container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            processor = coreProcessor {
+                bean = MessageListener(countDownLatch)
+                method = MessageListener::class.java.getMethod("processMessage")
+            }
+            retriever = prefetchingMessageRetriever {
+                desiredPrefetchedMessages = 1
+                maxPrefetchedMessages = 2
+            }
+            resolver = batchingResolver {
+                bufferingSizeLimit = { 1 }
+                bufferingTime = { Duration.ofSeconds(1) }
+            }
+            broker = concurrentBroker {
+                concurrencyLevel = { 1 }
+            }
+            shutdown {
+                messageBrokerShutdownTimeout = Duration.ofSeconds(5)
+                messageProcessingShutdownTimeout = Duration.ofSeconds(5)
+                messageResolverShutdownTimeout = Duration.ofSeconds(5)
+                messageRetrieverShutdownTimeout = Duration.ofSeconds(5)
+                shouldInterruptThreadsProcessingMessages = true
+                shouldProcessAnyExtraRetrievedMessages = true
+            }
+        }
+        container?.start()
+        container?.stop()
+        sqsAsyncClient.close()
+    }
+
+    inner class MessageListener(private val countDownLatch: CountDownLatch) {
+        @Suppress("unused")
+        fun processMessage() {
+            countDownLatch.countDown()
+        }
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/decorators/CoreMessageProcessingDecoratorsDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/decorators/CoreMessageProcessingDecoratorsDslBuilderTest.kt
@@ -1,0 +1,24 @@
+package com.jashmore.sqs.core.kotlin.dsl.decorators
+
+import com.jashmore.sqs.decorator.MessageProcessingDecorator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+
+class CoreMessageProcessingDecoratorsDslBuilderTest {
+
+    @Test
+    fun `should be able to construct all decorators from provided ones`() {
+        // arrange
+        val decoratorOne = mock(MessageProcessingDecorator::class.java)
+        val decoratorTwo = mock(MessageProcessingDecorator::class.java)
+        val builder = CoreMessageProcessingDecoratorsDslDslBuilder()
+
+        // act
+        builder.add(decoratorOne)
+        builder.add(decoratorTwo)
+
+        // assert
+        assertThat(builder()).containsExactly(decoratorOne, decoratorTwo)
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/processor/CoreMessageProcessorDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/processor/CoreMessageProcessorDslBuilderTest.kt
@@ -1,0 +1,138 @@
+package com.jashmore.sqs.core.kotlin.dsl.processor
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.argument.ArgumentResolver
+import com.jashmore.sqs.argument.MethodParameter
+import com.jashmore.sqs.argument.payload.Payload
+import com.jashmore.sqs.core.kotlin.dsl.argument.delegatingArgumentResolverService
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.decorator.MessageProcessingDecorator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.Message
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+private val payloadReference: AtomicReference<String> = AtomicReference()
+
+@ExtendWith(MockitoExtension::class)
+class CoreMessageProcessorDslBuilderTest {
+    private val queueProperties = QueueProperties.builder()
+            .queueUrl("url")
+            .build()
+
+    @Mock
+    lateinit var sqsAsyncClient: SqsAsyncClient
+
+    @BeforeEach
+    internal fun setUp() {
+        payloadReference.set(null)
+    }
+
+    @Test
+    fun `no bean will throw exception building component`() {
+        // act
+        val exception = assertThrows(RequiredFieldException::class.java) {
+            coreProcessor("identifier", sqsAsyncClient, queueProperties) {
+                method = CoreMessageProcessorDslBuilderTest::class.java.getMethod("myMethod", String::class.java)
+            }()
+        }
+
+        // assert
+        assertThat(exception).hasMessage("bean is required for CoreMessageProcessor")
+    }
+
+    @Test
+    fun `no method will throw exception building component`() {
+        // act
+        val exception = assertThrows(RequiredFieldException::class.java) {
+            coreProcessor("identifier", sqsAsyncClient, queueProperties) {
+                bean = Object()
+            }()
+        }
+
+        // assert
+        assertThat(exception).hasMessage("method is required for CoreMessageProcessor")
+    }
+
+    @Test
+    fun `no argument resolver will set up defaults`() {
+        // act
+        val coreProcessor = coreProcessor("identifier", sqsAsyncClient, queueProperties) {
+            bean = CoreMessageProcessorDslBuilderTest()
+            method = CoreMessageProcessorDslBuilderTest::class.java.getMethod("myMethod", String::class.java)
+        }()
+
+        coreProcessor.processMessage(Message.builder().body("test").build()) { CompletableFuture.completedFuture(null) }.get(5, TimeUnit.SECONDS)
+
+        // assert
+        assertThat(payloadReference.get()).isEqualTo("test")
+    }
+
+    @Test
+    fun `custom argument resolvers can be configured`() {
+        // act
+        val coreProcessor = coreProcessor("identifier", sqsAsyncClient, queueProperties) {
+            argumentResolverService = delegatingArgumentResolverService {
+                add(object : ArgumentResolver<String> {
+                    override fun canResolveParameter(methodParameter: MethodParameter?): Boolean = true
+
+                    override fun resolveArgumentForParameter(queueProperties: QueueProperties,
+                                                             methodParameter: MethodParameter,
+                                                             message: Message): String = "some value"
+                })
+            }
+            bean = CoreMessageProcessorDslBuilderTest()
+            method = CoreMessageProcessorDslBuilderTest::class.java.getMethod("myMethod", String::class.java)
+        }()
+
+        coreProcessor.processMessage(Message.builder().body("test").build()) { CompletableFuture.completedFuture(null) }.get(5, TimeUnit.SECONDS)
+
+        // assert
+        assertThat(payloadReference.get()).isEqualTo("some value")
+    }
+
+    @Test
+    fun `adding decorators will wrap in DecoratingMessageProcessor`() {
+        // act
+        val mockDecorator = mock(MessageProcessingDecorator::class.java)
+        val coreProcessor = coreProcessor("identifier", sqsAsyncClient, queueProperties) {
+            argumentResolverService = delegatingArgumentResolverService {
+                add(object : ArgumentResolver<String> {
+                    override fun canResolveParameter(methodParameter: MethodParameter?): Boolean = true
+
+                    override fun resolveArgumentForParameter(queueProperties: QueueProperties,
+                                                             methodParameter: MethodParameter,
+                                                             message: Message): String = "some value"
+                })
+            }
+            bean = CoreMessageProcessorDslBuilderTest()
+            method = CoreMessageProcessorDslBuilderTest::class.java.getMethod("myMethod", String::class.java)
+            decorators {
+                add(mockDecorator)
+            }
+        }()
+
+        val message = Message.builder().body("test").build()
+        coreProcessor.processMessage(message) { CompletableFuture.completedFuture(null) }.get(5, TimeUnit.SECONDS)
+
+        // assert
+        verify(mockDecorator).onPreMessageProcessing(any(), eq(message))
+    }
+
+    @Suppress("unused")
+    fun myMethod(@Payload payload: String) {
+        payloadReference.set(payload)
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilderTest.kt
@@ -1,0 +1,169 @@
+package com.jashmore.sqs.core.kotlin.dsl.retriever
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.util.ExpectedTestException
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import software.amazon.awssdk.core.exception.SdkClientException
+import software.amazon.awssdk.core.exception.SdkInterruptedException
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@ExtendWith(MockitoExtension::class)
+class BatchingMessageRetrieverDslBuilderTest {
+    private val queueProperties = QueueProperties.builder()
+            .queueUrl("url")
+            .build()
+
+    @Mock
+    lateinit var sqsAsyncClient: SqsAsyncClient
+
+    @Test
+    fun `no batchSize set will throw exception`() {
+        val exception = Assertions.assertThrows(RequiredFieldException::class.java) {
+            batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+                batchingPeriod = { Duration.ofSeconds(5) }
+            }()
+        }
+
+        assertThat(exception).hasMessage("batchSize is required for BatchingMessageRetriever")
+    }
+
+    @Test
+    fun `no batchingPeriod set will throw exception`() {
+        val exception = Assertions.assertThrows(RequiredFieldException::class.java) {
+            batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+                batchSize = { 2 }
+            }()
+        }
+
+        assertThat(exception).hasMessage("batchingPeriod is required for BatchingMessageRetriever")
+    }
+
+    @Test
+    fun `will wait supplied batching period before requesting messages`() {
+        // arrange
+        var count = 0
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer {
+                    ++count
+                    when (count) {
+                        1 -> CompletableFuture.completedFuture(ReceiveMessageResponse.builder()
+                                .messages(listOf())
+                                .build())
+                        else -> throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+                    }
+                }
+
+        // act
+        val retriever = batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            batchSize = { 2 }
+            batchingPeriod = { Duration.ofMillis(200) }
+        }()
+        val startTime = System.currentTimeMillis()
+        retriever.retrieveMessage()
+        runRetriever(retriever)
+        val endTime = System.currentTimeMillis()
+
+        // assert
+        assertThat(endTime - startTime).isGreaterThanOrEqualTo(200)
+    }
+
+    @Test
+    fun `will request messages as soon as the batch size is reached`() {
+        // arrange
+        var count = 0
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer {
+                    ++count
+                    when (count) {
+                        1 -> CompletableFuture.completedFuture(ReceiveMessageResponse.builder()
+                                .messages(listOf())
+                                .build())
+                        else -> throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+                    }
+                }
+
+        // act
+        val retriever = batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            batchSize = { 2 }
+            batchingPeriod = { Duration.ofMillis(200) }
+        }()
+        val startTime = System.currentTimeMillis()
+        retriever.retrieveMessage()
+        retriever.retrieveMessage()
+        runRetriever(retriever)
+        val endTime = System.currentTimeMillis()
+
+        // assert
+        assertThat(endTime - startTime).isLessThan(200)
+    }
+
+    @Test
+    fun `setting error backoff time using supplier will wait that amount of time`() {
+        // arrange
+        var count = 0
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer {
+                    ++count
+                    when (count) {
+                        1 -> throw ExpectedTestException()
+                        else -> throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+                    }
+                }
+
+        // act
+        val retriever = batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            batchSize = { 1 }
+            batchingPeriod = { Duration.ofSeconds(5) }
+            errorBackoffTime = { Duration.ofMillis(500) }
+        }()
+        val startTime = System.currentTimeMillis()
+        retriever.retrieveMessage()
+        runRetriever(retriever)
+        val endTime = System.currentTimeMillis()
+
+        // assert
+        assertThat(endTime - startTime).isGreaterThanOrEqualTo(500)
+    }
+
+    @Test
+    fun `setting message visibility using supplier will set that in request`() {
+        // arrange
+        val actualRequest = AtomicReference<ReceiveMessageRequest>()
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer {
+                    actualRequest.set(it.arguments[0] as ReceiveMessageRequest)
+                    throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+                }
+
+        // act
+        val retriever = batchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            batchSize = { 1 }
+            batchingPeriod = { Duration.ofSeconds(5) }
+            messageVisibility = { Duration.ofSeconds(30) }
+        }()
+        retriever.retrieveMessage()
+        runRetriever(retriever)
+
+        // assert
+        assertThat(actualRequest.get().visibilityTimeout()).isEqualTo(30)
+    }
+
+    private fun runRetriever(retriever: MessageRetriever) {
+        CompletableFuture.runAsync { retriever.run() }.get(5, TimeUnit.SECONDS)
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilderTest.kt
@@ -1,0 +1,146 @@
+package com.jashmore.sqs.core.kotlin.dsl.retriever
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.core.kotlin.dsl.utils.RequiredFieldException
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.util.ExpectedTestException
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.stubbing.Answer
+import software.amazon.awssdk.core.exception.SdkClientException
+import software.amazon.awssdk.core.exception.SdkInterruptedException
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+class PrefetchingMessageRetrieverDslBuilderTest {
+    private val queueProperties = QueueProperties.builder()
+            .queueUrl("url")
+            .build()
+
+    @Mock
+    lateinit var sqsAsyncClient: SqsAsyncClient
+
+    @Test
+    fun `no desired prefetched messages set will throw exception`() {
+        val exception = assertThrows(RequiredFieldException::class.java) {
+            prefetchingMessageRetriever(sqsAsyncClient, queueProperties) {
+                maxPrefetchedMessages = 2
+            }()
+        }
+
+        assertThat(exception).hasMessage("desiredPrefetchedMessages is required for PrefetchingMessageRetriever")
+    }
+
+    @Test
+    fun `no max prefetched messages set will throw exception`() {
+        val exception = assertThrows(RequiredFieldException::class.java) {
+            prefetchingMessageRetriever(sqsAsyncClient, queueProperties) {
+                desiredPrefetchedMessages = 2
+            }()
+        }
+
+        assertThat(exception).hasMessage("maxPrefetchedMessages is required for PrefetchingMessageRetriever")
+    }
+
+    @Test
+    fun `setting visibility timeout using supplier will be included in request to SQS`() {
+        // arrange
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer(runReceiveMessageOnce())
+        var firstRequest = true
+
+        // act
+        val retriever = prefetchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            desiredPrefetchedMessages = 2
+            maxPrefetchedMessages = 4
+            messageVisibility = {
+                if (firstRequest) {
+                    firstRequest = false
+                    Duration.ofSeconds(1)
+                } else {
+                    Duration.ofSeconds(2)
+                }
+            }
+        }()
+        runRetriever(retriever)
+
+        // assert
+        val sendMessageRequestCaptor = ArgumentCaptor.forClass(ReceiveMessageRequest::class.java)
+        verify(sqsAsyncClient, times(2)).receiveMessage(sendMessageRequestCaptor.capture())
+        assertThat(sendMessageRequestCaptor.allValues[0].visibilityTimeout()).isEqualTo(Duration.ofSeconds(1).seconds)
+        assertThat(sendMessageRequestCaptor.allValues[1].visibilityTimeout()).isEqualTo(Duration.ofSeconds(2).seconds)
+    }
+
+    @Test
+    fun `setting error backoff time using supplier will wait that amount of time`() {
+        // arrange
+        whenever(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest::class.java)))
+                .thenAnswer(runReceiveMessageFailure(times = 2))
+        var isFirst = true
+
+        // act
+        val retriever = prefetchingMessageRetriever(sqsAsyncClient, queueProperties) {
+            desiredPrefetchedMessages = 2
+            maxPrefetchedMessages = 4
+            errorBackoffTime = {
+                if (isFirst) {
+                    isFirst = false
+                    Duration.ofMillis(500)
+                } else {
+                    Duration.ofMillis(1000)
+                }
+            }
+        }()
+        val startTime = System.currentTimeMillis()
+        runRetriever(retriever)
+        val endTime = System.currentTimeMillis()
+
+        // assert
+        assertThat(endTime - startTime).isGreaterThan(1500)
+    }
+
+    private fun runReceiveMessageOnce(): Answer<*> {
+        var count = 0
+        val times = 1
+        return Answer {
+            if (count < times) {
+                ++count
+                CompletableFuture.completedFuture(ReceiveMessageResponse.builder()
+                        .messages(listOf())
+                        .build())
+            } else {
+                throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+            }
+        }
+    }
+
+    private fun runReceiveMessageFailure(times: Int = 1): Answer<*> {
+        var count = 0
+        return Answer {
+            if (count < times) {
+                ++count
+                throw ExpectedTestException()
+            } else {
+                throw SdkClientException.create("Expected Test Error", SdkInterruptedException())
+            }
+        }
+    }
+
+    private fun runRetriever(retriever: MessageRetriever) {
+        CompletableFuture.runAsync { retriever.run() }.get(5, TimeUnit.SECONDS)
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/CachingDslUtilsKtTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/utils/CachingDslUtilsKtTest.kt
@@ -1,0 +1,54 @@
+package com.jashmore.sqs.core.kotlin.dsl.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class CachingDslUtilsKtTest {
+
+    @Nested
+    inner class Cached {
+        @Test
+        fun `should call to delegate the first time the supplier is used`() {
+            val cachedSupplier = cached(Duration.ofMillis(500)) { 5 }
+            assertThat(cachedSupplier()).isEqualTo(5)
+        }
+
+        @Test
+        fun `should keep same value while timeout has not expired`() {
+            var count = 0
+            val cachedSupplier = cached(Duration.ofMillis(500)) { count++ }
+            assertThat(cachedSupplier()).isEqualTo(0)
+            assertThat(cachedSupplier()).isEqualTo(0)
+            assertThat(cachedSupplier()).isEqualTo(0)
+        }
+
+        @Test
+        fun `should use new value when timeout has expired`() {
+            var count = 0
+            val cachedSupplier = cached(Duration.ofMillis(500)) { count++ }
+            assertThat(cachedSupplier()).isEqualTo(0)
+
+            Thread.sleep(501)
+
+            assertThat(cachedSupplier()).isEqualTo(1)
+            assertThat(cachedSupplier()).isEqualTo(1)
+        }
+
+        @Test
+        fun `will continually get new values when timeouts keeps expiring`() {
+            var count = 0
+            val cachedSupplier = cached(Duration.ofMillis(200)) { count++ }
+            assertThat(cachedSupplier()).isEqualTo(0)
+            Thread.sleep(100)
+            assertThat(cachedSupplier()).isEqualTo(0)
+            Thread.sleep(200)
+            assertThat(cachedSupplier()).isEqualTo(1)
+            Thread.sleep(150)
+            assertThat(cachedSupplier()).isEqualTo(1)
+            Thread.sleep(100)
+            assertThat(cachedSupplier()).isEqualTo(2)
+        }
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/resources/logback.xml
+++ b/extensions/core-kotlin-dsl/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg %yellow(%mdc) %n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- We reduce the log messages from ElasticMQ, Akka and Netty to reduce the amount of unnecessary log messages being published -->
+    <logger name="org.elasticmq" level="OFF" />
+    <logger name="akka" level="OFF" />
+    <logger name="io.netty" level="ERROR" />
+
+    <logger name="com.jashmore" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
         ":aws-xray-extension-core",
         ":aws-xray-extension-spring-boot",
         ":brave-message-processing-decorator",
+        ":core-kotlin-dsl",
 
         // - Spring Cloud Scheme Registry Extension
         ":spring-cloud-schema-registry-extension-api",
@@ -47,6 +48,7 @@ include(
         ":aws-xray-spring-example",
         ":java-dynamic-sqs-listener-core-examples",
         ":java-dynamic-sqs-listener-spring-aws-example",
+        ":core-kotlin-example",
         ":spring-cloud-schema-registry-consumer",
         ":spring-cloud-schema-registry-producer",
         ":spring-cloud-schema-registry-producer-two",
@@ -63,6 +65,7 @@ project(":java-dynamic-sqs-listener-core").projectDir = file("core")
 project(":aws-xray-spring-example").projectDir = file("examples/aws-xray-spring-example")
 project(":java-dynamic-sqs-listener-core-examples").projectDir = file("examples/core-examples")
 project(":java-dynamic-sqs-listener-spring-aws-example").projectDir = file("examples/spring-aws-example")
+project(":core-kotlin-example").projectDir = file("examples/core-kotlin-example")
 project(":spring-cloud-schema-registry-consumer").projectDir = file("examples/spring-cloud-schema-registry-example/spring-cloud-schema-registry-consumer")
 project(":spring-cloud-schema-registry-producer").projectDir = file("examples/spring-cloud-schema-registry-example/spring-cloud-schema-registry-producer")
 project(":spring-cloud-schema-registry-producer-two").projectDir = file("examples/spring-cloud-schema-registry-example/spring-cloud-schema-registry-producer-two")
@@ -75,6 +78,7 @@ project(":sqs-listener-library-comparison").projectDir = file("examples/sqs-list
 project(":aws-xray-extension-core").projectDir = file("extensions/aws-xray-extension/core")
 project(":aws-xray-extension-spring-boot").projectDir = file("extensions/aws-xray-extension/spring-boot")
 project(":brave-message-processing-decorator").projectDir = file("extensions/brave-message-processing-decorator")
+project(":core-kotlin-dsl").projectDir = file("extensions/core-kotlin-dsl")
 project(":spring-cloud-schema-registry-extension-api").projectDir = file("extensions/spring-cloud-schema-registry-extension/spring-cloud-schema-registry-extension-api")
 project(":avro-spring-cloud-schema-registry-extension").projectDir = file("extensions/spring-cloud-schema-registry-extension/avro-spring-cloud-schema-registry-extension")
 project(":in-memory-spring-cloud-schema-registry").projectDir = file("extensions/spring-cloud-schema-registry-extension/in-memory-spring-cloud-schema-registry")


### PR DESCRIPTION
This allows you to more easily create a MessageListenerContainer using
a simpler Kotlin DSL format. An example is something like:

```kotlin
val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
    retriever = prefetchingMessageRetriever {
        desiredPrefetchedMessages = 10
        maxPrefetchedMessages = 20
    }
    processor = coreProcessor {
        argumentResolverService = coreArgumentResolverService(objectMapper)
        bean = MessageListener()
        method = MessageListener::class.java.getMethod("listen", String::class.java)
    }
    broker = concurrentBroker {
        concurrencyLevel = { 10 }
        concurrencyPollingRate = { Duration.ofSeconds(30) }
    }
    resolver = batchingResolver {
        bufferingSizeLimit = { 5 }
        bufferingTime = { Duration.ofSeconds(2) }
    }
}
```