### PR TITLE
refs #231: Converts properties to use Durations and not Numbers

### DIFF
--- a/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBroker.java
+++ b/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBroker.java
@@ -90,7 +90,7 @@ public class ConcurrentMessageBroker implements MessageBroker {
     /**
      * Safely get the number of milliseconds that should wait to get a permit for creating a new thread.
      *
-     * @return the durationToWaitFor
+     * @return the duration to wait for an available permit
      * @see ConcurrentMessageBrokerProperties#getConcurrencyPollingRate() for more information
      */
     private Duration getPermitWaitTime() {

--- a/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerConstants.java
+++ b/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerConstants.java
@@ -2,15 +2,17 @@ package com.jashmore.sqs.broker.concurrent;
 
 import lombok.experimental.UtilityClass;
 
+import java.time.Duration;
+
 @UtilityClass
 class ConcurrentMessageBrokerConstants {
     /**
      * The default amount of time to sleep the thread when there was an error organising the message processing threads.
      */
-    static final int DEFAULT_BACKOFF_TIME_IN_MS = 10_000;
+    static final Duration DEFAULT_BACKOFF_TIME = Duration.ofSeconds(10);
 
     /**
      * The default amount of time the thread should wait for a thread to process a message before it tries again and checks the available concurrency.
      */
-    static final long DEFAULT_CONCURRENCY_POLLING_IN_MS = 60_000L;
+    static final Duration DEFAULT_CONCURRENCY_POLLING = Duration.ofMinutes(1);
 }

--- a/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerProperties.java
@@ -2,6 +2,7 @@ package com.jashmore.sqs.broker.concurrent;
 
 import com.jashmore.documentation.annotations.NotThreadSafe;
 import com.jashmore.documentation.annotations.Nullable;
+import com.jashmore.documentation.annotations.Positive;
 import com.jashmore.documentation.annotations.PositiveOrZero;
 
 import java.time.Duration;
@@ -64,12 +65,14 @@ public interface ConcurrentMessageBrokerProperties {
      * that the coordinating thread is awoken and is therefore less CPU intensive. However, decreasing this polling period makes it more responsive to changes
      * to the rate of concurrency.
      *
-     * <p>If this duration is null or negative, {@link ConcurrentMessageBrokerConstants#DEFAULT_CONCURRENCY_POLLING} will be used instead.
+     * <p>If this duration is null or negative, {@link ConcurrentMessageBrokerConstants#DEFAULT_CONCURRENCY_POLLING} will be used instead. It is not
+     * recommended to have a low value as that will result in this background thread constantly trying to determine fi the concurrency rate can be
+     * changed.
      *
      * @return the amount of time between polls for the concurrency level
      */
     @Nullable
-    @PositiveOrZero
+    @Positive
     Duration getConcurrencyPollingRate();
 
     /**

--- a/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/broker/concurrent/ConcurrentMessageBrokerProperties.java
@@ -4,6 +4,8 @@ import com.jashmore.documentation.annotations.NotThreadSafe;
 import com.jashmore.documentation.annotations.Nullable;
 import com.jashmore.documentation.annotations.PositiveOrZero;
 
+import java.time.Duration;
+
 /**
  * Properties for dynamically configuring how the {@link ConcurrentMessageBroker} is able to process messages concurrently.
  *
@@ -25,7 +27,7 @@ public interface ConcurrentMessageBrokerProperties {
      * <p>The {@link ConcurrentMessageBroker} will maintain the rate of concurrency by checking that the current concurrency rate is aligned with this value.
      * If there is currently less messages being processed than this value, more requests for messages will be made to meet this value. If there are
      * more messages being processed or requested than this value, this coordinating thread will block until enough messages have been processed.  If a
-     * permit has not be obtained before the timeout defined by {@link #getConcurrencyPollingRateInMilliseconds()}, it will recalculate this
+     * permit has not be obtained before the timeout defined by {@link #getConcurrencyPollingRate()}, it will recalculate this
      * concurrency rate again and wait for a permit.
      *
      * <p>Note that the concurrency rate does not get applied instantly and there are multiple attributing factors for when the rate of concurrency will
@@ -40,7 +42,7 @@ public interface ConcurrentMessageBrokerProperties {
      *     </li>
      *     <li>
      *         The delay in the concurrency rate change may be due to transitioning from allowing zero threads to a number of threads. In a worst
-     *         case scenario there would be a delay of {@link #getConcurrencyPollingRateInMilliseconds()} before the rate of concurrency is changed.
+     *         case scenario there would be a delay of {@link #getConcurrencyPollingRate()} before the rate of concurrency is changed.
      *     </li>
      * </ul>
      *
@@ -50,7 +52,7 @@ public interface ConcurrentMessageBrokerProperties {
     int getConcurrencyLevel();
 
     /**
-     * The number of milliseconds that the coordinating thread will sleep when the maximum rate of concurrency has been reached before checking the
+     * The duration that the coordinating thread will sleep when the maximum rate of concurrency has been reached before checking the
      * concurrency rate again.
      *
      * <p>The reason that this property is needed is because during the processing of messages, which could be a significantly long period, the rate
@@ -62,25 +64,25 @@ public interface ConcurrentMessageBrokerProperties {
      * that the coordinating thread is awoken and is therefore less CPU intensive. However, decreasing this polling period makes it more responsive to changes
      * to the rate of concurrency.
      *
-     * <p>If this value is null or less than zero, {@link ConcurrentMessageBrokerConstants#DEFAULT_CONCURRENCY_POLLING_IN_MS} will be used instead.
+     * <p>If this duration is null or negative, {@link ConcurrentMessageBrokerConstants#DEFAULT_CONCURRENCY_POLLING} will be used instead.
      *
-     * @return the number of milliseconds between polls for the concurrency level
+     * @return the amount of time between polls for the concurrency level
      */
     @Nullable
     @PositiveOrZero
-    Long getConcurrencyPollingRateInMilliseconds();
+    Duration getConcurrencyPollingRate();
 
     /**
-     * The number of milliseconds that the coordinating thread should backoff if there was an error trying to request a message.
+     * The duration that the coordinating thread should backoff if there was an error trying to request a message.
      *
      * <p>This is needed to stop the background thread from trying again and again over and over causing a flood of error log messages that may make it
      * difficult to debug.
      *
-     * <p>If this value is null or negative, {@link ConcurrentMessageBrokerConstants#DEFAULT_BACKOFF_TIME_IN_MS} will be used as the backoff period.
+     * <p>If this value is null or negative, {@link ConcurrentMessageBrokerConstants#DEFAULT_BACKOFF_TIME} will be used as the backoff period.
      *
-     * @return the number of milliseconds to sleep the thread after an error is thrown
+     * @return the amount of time to sleep the thread after an error is thrown
      */
     @Nullable
     @PositiveOrZero
-    Long getErrorBackoffTimeInMilliseconds();
+    Duration getErrorBackoffTime();
 }

--- a/core/src/main/java/com/jashmore/sqs/broker/concurrent/StaticConcurrentMessageBrokerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/broker/concurrent/StaticConcurrentMessageBrokerProperties.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.time.Duration;
+
 /**
  * Implementation that stores the value as non-mutable field values and therefore will return the same value on every call.
  *
@@ -21,20 +23,18 @@ import lombok.ToString;
 @ThreadSafe
 public final class StaticConcurrentMessageBrokerProperties implements ConcurrentMessageBrokerProperties {
     private final Integer concurrencyLevel;
-    private final Long preferredConcurrencyPollingRateInMilliseconds;
-    private final Long errorBackoffTimeInMilliseconds;
+    private final Duration preferredConcurrencyPollingRate;
+    private final Duration errorBackoffTime;
 
     public StaticConcurrentMessageBrokerProperties(final Integer concurrencyLevel,
-                                                   final Long preferredConcurrencyPollingRateInMilliseconds,
-                                                   final Long errorBackoffTimeInMilliseconds) {
+                                                   final Duration preferredConcurrencyPollingRate,
+                                                   final Duration errorBackoffTime) {
         Preconditions.checkNotNull(concurrencyLevel, "concurrencyLevel should not be null");
         Preconditions.checkPositiveOrZero(concurrencyLevel, "concurrencyLevel should be greater than or equal to zero");
-        Preconditions.checkArgument(preferredConcurrencyPollingRateInMilliseconds == null || preferredConcurrencyPollingRateInMilliseconds >= 0,
-                "preferredConcurrencyPollingRateInMilliseconds should null or greater than or equal to zero");
 
         this.concurrencyLevel = concurrencyLevel;
-        this.preferredConcurrencyPollingRateInMilliseconds = preferredConcurrencyPollingRateInMilliseconds;
-        this.errorBackoffTimeInMilliseconds = errorBackoffTimeInMilliseconds;
+        this.preferredConcurrencyPollingRate = preferredConcurrencyPollingRate;
+        this.errorBackoffTime = errorBackoffTime;
     }
 
     @PositiveOrZero
@@ -43,16 +43,17 @@ public final class StaticConcurrentMessageBrokerProperties implements Concurrent
         return concurrencyLevel;
     }
 
+    @Nullable
     @PositiveOrZero
     @Override
-    public Long getConcurrencyPollingRateInMilliseconds() {
-        return preferredConcurrencyPollingRateInMilliseconds;
+    public Duration getConcurrencyPollingRate() {
+        return preferredConcurrencyPollingRate;
     }
 
     @Nullable
     @PositiveOrZero
     @Override
-    public Long getErrorBackoffTimeInMilliseconds() {
-        return errorBackoffTimeInMilliseconds;
+    public Duration getErrorBackoffTime() {
+        return errorBackoffTime;
     }
 }

--- a/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerConstants.java
+++ b/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerConstants.java
@@ -3,12 +3,14 @@ package com.jashmore.sqs.container;
 import com.jashmore.sqs.retriever.MessageRetriever;
 import lombok.experimental.UtilityClass;
 
+import java.time.Duration;
+
 @UtilityClass
 class CoreMessageListenerContainerConstants {
     /**
-     * The default time that the broker will wait for each background thread to shutdown before giving up.
+     * The default time that the container will wait for a component to shutdown before giving up.
      */
-    static final int DEFAULT_SHUTDOWN_TIME_IN_SECONDS = 60;
+    static final Duration DEFAULT_SHUTDOWN_TIME = Duration.ofSeconds(60);
 
     /**
      * The default setting for whether the current messages being processed should be interrupted when the container is being shut down.

--- a/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
@@ -37,7 +37,7 @@ public interface CoreMessageListenerContainerProperties {
      * Gets the amount of time that the container should wait for the {@link com.jashmore.sqs.broker.MessageBroker} to shutdown when the broker is
      * being shutdown.
      *
-     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used instead.
      *
      * @return the amount of time to wait for the message retriever to shutdown
      */
@@ -48,7 +48,7 @@ public interface CoreMessageListenerContainerProperties {
     /**
      * Gets the amount of time that the container should wait for the {@link MessageRetriever} to shutdown when the broker is being shutdown.
      *
-     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used instead.
      *
      * @return the amount of time to wait for the message retriever to shutdown
      */
@@ -62,7 +62,7 @@ public interface CoreMessageListenerContainerProperties {
      * <p>When {@link #shouldProcessAnyExtraRetrievedMessagesOnShutdown()} is true and there are extra messages to be processed, this field will try and
      * put as many messages onto threads to be processed before this limit is hit. If this time limit is reached some messages may not have been processed.
      *
-     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used instead.
      *
      * @return the amount of time to wait for shutdown of message processing threads
      */
@@ -73,7 +73,7 @@ public interface CoreMessageListenerContainerProperties {
     /**
      * Gets the amount of time that the container should wait for the {@link MessageResolver} to shutdown when the broker is being shutdown.
      *
-     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used instead.
      *
      * @return the amount of time to wait for the message resolver to shutdown
      */

--- a/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/container/CoreMessageListenerContainerProperties.java
@@ -5,6 +5,8 @@ import com.jashmore.documentation.annotations.PositiveOrZero;
 import com.jashmore.sqs.resolver.MessageResolver;
 import com.jashmore.sqs.retriever.MessageRetriever;
 
+import java.time.Duration;
+
 public interface CoreMessageListenerContainerProperties {
     /**
      * Whether the threads that are processing messages should be interrupted during shutdown of the broker.
@@ -35,50 +37,47 @@ public interface CoreMessageListenerContainerProperties {
      * Gets the amount of time that the container should wait for the {@link com.jashmore.sqs.broker.MessageBroker} to shutdown when the broker is
      * being shutdown.
      *
-     * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
      *
-     * @return the number of seconds to wait for the message retriever to shutdown
+     * @return the amount of time to wait for the message retriever to shutdown
      */
     @Nullable
     @PositiveOrZero
-    default Integer getMessageBrokerShutdownTimeoutInSeconds() {
-        // Added to not cause an API breaking change
-        return null;
-    }
+    Duration getMessageBrokerShutdownTimeout();
 
     /**
      * Gets the amount of time that the container should wait for the {@link MessageRetriever} to shutdown when the broker is being shutdown.
      *
-     * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
      *
-     * @return the number of seconds to wait for the message retriever to shutdown
+     * @return the amount of time to wait for the message retriever to shutdown
      */
     @Nullable
     @PositiveOrZero
-    Integer getMessageRetrieverShutdownTimeoutInSeconds();
+    Duration getMessageRetrieverShutdownTimeout();
 
     /**
-     * The number of seconds that the container should wait for the message processing threads to finish when a shutdown is initiated.
+     * The amount of time that the container should wait for the message processing threads to finish when a shutdown is initiated.
      *
      * <p>When {@link #shouldProcessAnyExtraRetrievedMessagesOnShutdown()} is true and there are extra messages to be processed, this field will try and
      * put as many messages onto threads to be processed before this limit is hit. If this time limit is reached some messages may not have been processed.
      *
-     * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
      *
-     * @return the time in seconds to wait for shutdown of message processing threads
+     * @return the amount of time to wait for shutdown of message processing threads
      */
     @Nullable
     @PositiveOrZero
-    Integer getMessageProcessingShutdownTimeoutInSeconds();
+    Duration getMessageProcessingShutdownTimeout();
 
     /**
      * Gets the amount of time that the container should wait for the {@link MessageResolver} to shutdown when the broker is being shutdown.
      *
-     * <p>If this value is negative or null, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME_IN_SECONDS} will be used for instead.
+     * <p>If this value is null or negative, then {@link CoreMessageListenerContainerConstants#DEFAULT_SHUTDOWN_TIME} will be used for instead.
      *
-     * @return the number of seconds to wait for the message resolver to shutdown
+     * @return the amount of time to wait for the message resolver to shutdown
      */
     @Nullable
     @PositiveOrZero
-    Integer getMessageResolverShutdownTimeoutInSeconds();
+    Duration getMessageResolverShutdownTimeout();
 }

--- a/core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/container/StaticCoreMessageListenerContainerProperties.java
@@ -5,15 +5,17 @@ import com.jashmore.documentation.annotations.PositiveOrZero;
 import lombok.Builder;
 import lombok.Value;
 
+import java.time.Duration;
+
 @Value
 @Builder(toBuilder = true)
 public class StaticCoreMessageListenerContainerProperties implements CoreMessageListenerContainerProperties {
     Boolean shouldProcessAnyExtraRetrievedMessagesOnShutdown;
     Boolean shouldInterruptThreadsProcessingMessagesOnShutdown;
-    Integer messageProcessingShutdownTimeoutInSeconds;
-    Integer messageRetrieverShutdownTimeoutInSeconds;
-    Integer messageResolverShutdownTimeoutInSeconds;
-    Integer messageBrokerShutdownTimeoutInSeconds;
+    Duration messageProcessingShutdownTimeout;
+    Duration messageRetrieverShutdownTimeout;
+    Duration messageResolverShutdownTimeout;
+    Duration messageBrokerShutdownTimeout;
 
     @Nullable
     @Override
@@ -30,26 +32,28 @@ public class StaticCoreMessageListenerContainerProperties implements CoreMessage
     @Nullable
     @PositiveOrZero
     @Override
-    public Integer getMessageBrokerShutdownTimeoutInSeconds() {
-        return messageBrokerShutdownTimeoutInSeconds;
+    public Duration getMessageBrokerShutdownTimeout() {
+        return messageBrokerShutdownTimeout;
     }
 
     @Nullable
     @PositiveOrZero
     @Override
-    public Integer getMessageProcessingShutdownTimeoutInSeconds() {
-        return messageProcessingShutdownTimeoutInSeconds;
+    public Duration getMessageProcessingShutdownTimeout() {
+        return messageProcessingShutdownTimeout;
     }
 
     @Nullable
+    @PositiveOrZero
     @Override
-    public Integer getMessageRetrieverShutdownTimeoutInSeconds() {
-        return messageRetrieverShutdownTimeoutInSeconds;
+    public Duration getMessageRetrieverShutdownTimeout() {
+        return messageRetrieverShutdownTimeout;
     }
 
     @Nullable
+    @PositiveOrZero
     @Override
-    public Integer getMessageResolverShutdownTimeoutInSeconds() {
-        return messageResolverShutdownTimeoutInSeconds;
+    public Duration getMessageResolverShutdownTimeout() {
+        return messageResolverShutdownTimeout;
     }
 }

--- a/core/src/main/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolverProperties.java
@@ -1,24 +1,16 @@
 package com.jashmore.sqs.resolver.batching;
 
 import com.jashmore.documentation.annotations.Max;
-import com.jashmore.documentation.annotations.Min;
+import com.jashmore.documentation.annotations.Nonnull;
 import com.jashmore.documentation.annotations.Positive;
 import com.jashmore.sqs.aws.AwsConstants;
+
+import java.time.Duration;
 
 /**
  * Properties used for configuring the {@link BatchingMessageResolver} specifically the size of the buffer that should be used.
  */
 public interface BatchingMessageResolverProperties {
-    /**
-     * The amount of time that the message should rename in the buffer in milliseconds.
-     *
-     * <p>This value must be greater than or equal to zero as it does not make sense for it to be negative.
-     *
-     * @return the time in milliseconds that a message can be buffered for resolution
-     */
-    @Positive
-    long getBufferingTimeInMs();
-
     /**
      * The maximum size of the buffer before a batch of message resolution should be triggered.
      *
@@ -28,7 +20,19 @@ public interface BatchingMessageResolverProperties {
      *
      * @return the maximum number of messages that can be buffered before the batch should be submitted for resolution
      */
-    @Min(1)
+    @Positive
     @Max(AwsConstants.MAX_NUMBER_OF_MESSAGES_IN_BATCH)
     int getBufferingSizeLimit();
+
+    /**
+     * The amount of time that the message should remain in the buffer before a batch is sent.
+     *
+     * <p>This value must be greater than zero as it does not make sense for it to be negative. It is also recommended not to have this as a
+     * very small time duration as a small duration will result in a constant looping of the buffering thread.
+     *
+     * @return the amount of time that a message can be buffered for resolution
+     */
+    @Nonnull
+    @Positive
+    Duration getBufferingTime();
 }

--- a/core/src/main/java/com/jashmore/sqs/resolver/batching/StaticBatchingMessageResolverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/resolver/batching/StaticBatchingMessageResolverProperties.java
@@ -5,7 +5,10 @@ import static com.jashmore.sqs.aws.AwsConstants.MAX_NUMBER_OF_MESSAGES_IN_BATCH;
 import com.jashmore.documentation.annotations.Max;
 import com.jashmore.documentation.annotations.Positive;
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
+
+import java.time.Duration;
 
 /**
  * Static implementation that will contain constant size and time limit for the buffer.
@@ -13,19 +16,20 @@ import lombok.Value;
 @Value
 @Builder(toBuilder = true)
 public class StaticBatchingMessageResolverProperties implements BatchingMessageResolverProperties {
-    long bufferingTimeInMs;
     int bufferingSizeLimit;
-
-    @Positive
-    @Override
-    public long getBufferingTimeInMs() {
-        return bufferingTimeInMs;
-    }
+    Duration bufferingTime;
 
     @Positive
     @Max(MAX_NUMBER_OF_MESSAGES_IN_BATCH)
     @Override
     public int getBufferingSizeLimit() {
         return bufferingSizeLimit;
+    }
+
+    @NonNull
+    @Positive
+    @Override
+    public Duration getBufferingTime() {
+        return bufferingTime;
     }
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetriever.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetriever.java
@@ -130,7 +130,7 @@ public class BatchingMessageRetriever implements MessageRetriever {
     private Queue<CompletableFuture<Message>> obtainRequestForMessagesBatch() throws InterruptedException {
         final Queue<CompletableFuture<Message>> messagesToObtain = new LinkedList<>();
         final int batchSize = getBatchSize();
-        final Duration pollingPeriod = safelyGetPositiveOrZeroDuration("batchingPeriod", properties::getBatchingPeriod, DEFAULT_BACKOFF_TIME);
+        final Duration pollingPeriod = safelyGetPositiveOrZeroDuration("batchingPeriod", properties::getBatchingPeriod, Duration.ZERO);
         if (log.isDebugEnabled()) {
             log.debug("Waiting for {} requests for messages within {}ms. Total currently waiting: {}",
                     batchSize,

--- a/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverConstants.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverConstants.java
@@ -2,20 +2,17 @@ package com.jashmore.sqs.retriever.batching;
 
 import lombok.experimental.UtilityClass;
 
+import java.time.Duration;
+
 @UtilityClass
 class BatchingMessageRetrieverConstants {
     /**
      * The default amount of time to sleep the thread when there was an error obtaining messages.
      */
-    static final int DEFAULT_BACKOFF_TIME_IN_MS = 10_000;
+    static final Duration DEFAULT_BACKOFF_TIME = Duration.ofSeconds(10);
 
     /**
      * The default number of threads requesting messages for it trigger a request for messages.
      */
     static final int DEFAULT_BATCHING_TRIGGER = 1;
-
-    /**
-     * The default number of threads requesting messages for it trigger a request for messages.
-     */
-    static final long DEFAULT_BATCHING_PERIOD_IN_MS = Long.MAX_VALUE;
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
@@ -7,6 +7,8 @@ import com.jashmore.documentation.annotations.PositiveOrZero;
 import com.jashmore.sqs.aws.AwsConstants;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 
+import java.time.Duration;
+
 /**
  * The properties used to configure the {@link BatchingMessageRetriever} which will be continually polled throughout the execution and therefore the
  * values can change dynamically during runtime.
@@ -23,7 +25,7 @@ public interface BatchingMessageRetrieverProperties {
      * <p>This limit will be checked every time a new thread requests a message so it should be implemented in a performant manner, either by being non
      * CPU or IO intensive or by implementing caching.
      *
-     * <p>Note that this trigger size may not be reached due to the the waiting time going higher than {@link #getBatchingPeriodInMs()}, in
+     * <p>Note that this trigger size may not be reached due to the the waiting time going higher than {@link #getBatchingPeriod()}, in
      * this case it will just request as many messages as threads requesting messages.
      *
      * <p>This number should be smaller than the maximum number of messages that can be downloaded from AWS as it doesn't make much sense to have a batch size
@@ -42,15 +44,14 @@ public interface BatchingMessageRetrieverProperties {
      * <p>Note that the background thread threads will ignore this period if the current number of threads requesting messages goes over
      * the {@link #getBatchSize()} limit.
      *
-     * <p>If this number is zero, there will be no polling period and the background thread will wait indefinitely for the
-     * {@link #getBatchSize()} to be reached. If this value is null, the value will defaulted to zero and a warning will be logged
-     * indicating that this value should be specifically set.
+     * <p>This value must be greater than zero as it does not make sense for it to be negative. It is also recommended not to have this as a
+     * very small time duration as a small duration will result in a constant looping of the buffering thread.
      *
-     * @return the polling period in milliseconds between attempts to get messages
+     * @return the polling period between attempts to get messages
      */
     @Nullable
-    @PositiveOrZero
-    Long getBatchingPeriodInMs();
+    @Positive
+    Duration getBatchingPeriod();
 
     /**
      * Represents the time that messages received from the SQS queue should be invisible from other consumers of the queue before it is considered a failure
@@ -64,20 +65,20 @@ public interface BatchingMessageRetrieverProperties {
      */
     @Nullable
     @Positive
-    Integer getMessageVisibilityTimeoutInSeconds();
+    Duration getMessageVisibilityTimeout();
 
     /**
-     * The number of milliseconds that the background thread for receiving messages should sleep after an error is thrown.
+     * The amount of time that the background thread for receiving messages should sleep after an error is thrown.
      *
      * <p>This is needed to stop the background thread from constantly requesting for more messages which constantly throwing errors. For example, maybe the
      * connection to the SQS throws a 403 or some other error and we don't want to be constantly retrying to make the connection unnecessarily. This
      * therefore sleeps the thread for this period before attempting again.
      *
-     * <p>If this value is null, negative or zero, {@link BatchingMessageRetrieverConstants#DEFAULT_BACKOFF_TIME_IN_MS} will be used as the backoff period.
+     * <p>If this value is null, negative or zero, {@link BatchingMessageRetrieverConstants#DEFAULT_BACKOFF_TIME} will be used as the backoff period.
      *
      * @return the number of milliseconds to sleep the thread after an error is thrown
      */
     @Nullable
     @PositiveOrZero
-    Long getErrorBackoffTimeInMilliseconds();
+    Duration getErrorBackoffTime();
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/batching/BatchingMessageRetrieverProperties.java
@@ -74,7 +74,7 @@ public interface BatchingMessageRetrieverProperties {
      * connection to the SQS throws a 403 or some other error and we don't want to be constantly retrying to make the connection unnecessarily. This
      * therefore sleeps the thread for this period before attempting again.
      *
-     * <p>If this value is null, negative or zero, {@link BatchingMessageRetrieverConstants#DEFAULT_BACKOFF_TIME} will be used as the backoff period.
+     * <p>If this value is null or negative, {@link BatchingMessageRetrieverConstants#DEFAULT_BACKOFF_TIME} will be used as the backoff period.
      *
      * @return the number of milliseconds to sleep the thread after an error is thrown
      */

--- a/core/src/main/java/com/jashmore/sqs/retriever/batching/StaticBatchingMessageRetrieverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/batching/StaticBatchingMessageRetrieverProperties.java
@@ -6,6 +6,8 @@ import com.jashmore.documentation.annotations.PositiveOrZero;
 import lombok.Builder;
 import lombok.Value;
 
+import java.time.Duration;
+
 /**
  * Static implementation of the properties that will never change during the processing of the messages.
  */
@@ -13,9 +15,9 @@ import lombok.Value;
 @Builder(toBuilder = true)
 public class StaticBatchingMessageRetrieverProperties implements BatchingMessageRetrieverProperties {
     int batchSize;
-    Long batchingPeriodInMs;
-    Integer messageVisibilityTimeoutInSeconds;
-    Long errorBackoffTimeInMilliseconds;
+    Duration batchingPeriod;
+    Duration messageVisibilityTimeout;
+    Duration errorBackoffTime;
 
     @Positive
     @Override
@@ -24,23 +26,23 @@ public class StaticBatchingMessageRetrieverProperties implements BatchingMessage
     }
 
     @Nullable
-    @PositiveOrZero
+    @Positive
     @Override
-    public Long getBatchingPeriodInMs() {
-        return batchingPeriodInMs;
+    public Duration getBatchingPeriod() {
+        return batchingPeriod;
     }
 
     @Nullable
     @Positive
     @Override
-    public Integer getMessageVisibilityTimeoutInSeconds() {
-        return messageVisibilityTimeoutInSeconds;
+    public Duration getMessageVisibilityTimeout() {
+        return messageVisibilityTimeout;
     }
 
     @Nullable
     @PositiveOrZero
     @Override
-    public Long getErrorBackoffTimeInMilliseconds() {
-        return errorBackoffTimeInMilliseconds;
+    public Duration getErrorBackoffTime() {
+        return errorBackoffTime;
     }
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverConstants.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverConstants.java
@@ -2,10 +2,12 @@ package com.jashmore.sqs.retriever.prefetch;
 
 import lombok.experimental.UtilityClass;
 
+import java.time.Duration;
+
 @UtilityClass
 class PrefetchingMessageRetrieverConstants {
     /**
      * The default backoff timeout for when there is an error retrieving messages.
      */
-    static final int DEFAULT_ERROR_BACKOFF_TIMEOUT_IN_MILLISECONDS = 10_000;
+    static final Duration DEFAULT_ERROR_BACKOFF_TIMEOUT = Duration.ofSeconds(10);
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverProperties.java
@@ -5,6 +5,8 @@ import com.jashmore.documentation.annotations.Positive;
 import com.jashmore.documentation.annotations.PositiveOrZero;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 
+import java.time.Duration;
+
 public interface PrefetchingMessageRetrieverProperties {
     /**
      * The minimum number of messages that should be in the queue before it will request more messages.
@@ -46,29 +48,30 @@ public interface PrefetchingMessageRetrieverProperties {
     int getMaxPrefetchedMessages();
 
     /**
-     * The visibility timeout for the message.
+     * The visibility timeout for the message which represents the amount of time a message can be kept before it is assumed that it wasn't
+     * completed successfully.
      *
-     * <p>E.g. the number of seconds that a message can be kept before it is assumed that it wasn't completed and will be put back onto the queue
-     *
-     * <p>If this value is null, no visibility timeout will be set on the message retrieval.
+     * <p>If this value is null or non-positive, no visibility timeout will be set on the message retrieval.  Note that as the AWS API requires
+     * this to be in seconds, this duration will be round to the nearest second.
      *
      * @return the visibility timeout for messages where null means to use the SQS default visibility timeout
      * @see ReceiveMessageRequest#visibilityTimeout() for where this is applied against
      */
     @Nullable
     @Positive
-    Integer getMessageVisibilityTimeoutInSeconds();
+    Duration getMessageVisibilityTimeout();
 
     /**
-     * If there was an error retrieving a message from the remote server, the retriever will backoff and try again after this many milliseconds, which
-     * prevents constant cycling of this thread that achieves nothing.
+     * If there was an error retrieving a message from the remote server, the retriever will backoff and try again after this period.
      *
-     * <p>If this value is null or negative, {@link PrefetchingMessageRetrieverConstants#DEFAULT_ERROR_BACKOFF_TIMEOUT_IN_MILLISECONDS} will be used
+     * <p>This helps reduce a constant cycle of errors being thrown by this retriever.
+     *
+     * <p>If this value is null or negative, {@link PrefetchingMessageRetrieverConstants#DEFAULT_ERROR_BACKOFF_TIMEOUT} will be used
      * as the backoff period.
      *
-     * @return the backoff time in milliseconds or null if the default backoff time should be used
+     * @return the backoff time or null if the default backoff time should be used
      */
     @Nullable
     @PositiveOrZero
-    Integer getErrorBackoffTimeInMilliseconds();
+    Duration getErrorBackoffTime();
 }

--- a/core/src/main/java/com/jashmore/sqs/retriever/prefetch/StaticPrefetchingMessageRetrieverProperties.java
+++ b/core/src/main/java/com/jashmore/sqs/retriever/prefetch/StaticPrefetchingMessageRetrieverProperties.java
@@ -9,6 +9,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 
+import java.time.Duration;
+
 @Builder(toBuilder = true)
 @ToString
 @EqualsAndHashCode
@@ -17,8 +19,8 @@ public class StaticPrefetchingMessageRetrieverProperties implements PrefetchingM
     private final Integer desiredMinPrefetchedMessages;
     @NonNull
     private final Integer maxPrefetchedMessages;
-    private final Integer messageVisibilityTimeoutInSeconds;
-    private final Integer errorBackoffTimeInMilliseconds;
+    private final Duration messageVisibilityTimeout;
+    private final Duration errorBackoffTime;
 
     @Override
     @Positive
@@ -35,14 +37,14 @@ public class StaticPrefetchingMessageRetrieverProperties implements PrefetchingM
     @Override
     @Nullable
     @Positive
-    public Integer getMessageVisibilityTimeoutInSeconds() {
-        return messageVisibilityTimeoutInSeconds;
+    public Duration getMessageVisibilityTimeout() {
+        return messageVisibilityTimeout;
     }
 
     @Override
     @Nullable
     @PositiveOrZero
-    public Integer getErrorBackoffTimeInMilliseconds() {
-        return errorBackoffTimeInMilliseconds;
+    public Duration getErrorBackoffTime() {
+        return errorBackoffTime;
     }
 }

--- a/core/src/test/java/com/jashmore/sqs/broker/concurrent/StaticConcurrentMessageBrokerPropertiesTest.java
+++ b/core/src/test/java/com/jashmore/sqs/broker/concurrent/StaticConcurrentMessageBrokerPropertiesTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 class StaticConcurrentMessageBrokerPropertiesTest {
     @Test
     void concurrencyLevelReturnedFromConstructor() {
         // act
-        final StaticConcurrentMessageBrokerProperties retriever = StaticConcurrentMessageBrokerProperties
-                .builder()
+        final StaticConcurrentMessageBrokerProperties retriever = StaticConcurrentMessageBrokerProperties.builder()
                 .concurrencyLevel(1)
                 .build();
 
@@ -21,31 +22,33 @@ class StaticConcurrentMessageBrokerPropertiesTest {
     @Test
     void negativeConcurrencyLevelThrowsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () ->
-                StaticConcurrentMessageBrokerProperties
-                        .builder()
+                StaticConcurrentMessageBrokerProperties.builder()
                         .concurrencyLevel(-1)
                         .build());
     }
 
     @Test
-    void concurrencyPollingLevelReturnedFromConstructor() {
+    void concurrencyPollingRateReturnedFromConstructor() {
         // act
-        final StaticConcurrentMessageBrokerProperties retriever = StaticConcurrentMessageBrokerProperties
-                .builder()
-                .preferredConcurrencyPollingRateInMilliseconds(1L)
+        final StaticConcurrentMessageBrokerProperties retriever = StaticConcurrentMessageBrokerProperties.builder()
+                .preferredConcurrencyPollingRate(Duration.ofMillis(1))
                 .concurrencyLevel(1)
                 .build();
 
         // assert
-        assertThat(retriever.getConcurrencyPollingRateInMilliseconds()).isEqualTo(1);
+        assertThat(retriever.getConcurrencyPollingRate()).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
-    void negativeConcurrencyPollingRateThrowsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> StaticConcurrentMessageBrokerProperties
-                .builder()
+    void errorBackoffTimeReturnedFromConstructor() {
+        // act
+        final StaticConcurrentMessageBrokerProperties retriever = StaticConcurrentMessageBrokerProperties.builder()
+                .preferredConcurrencyPollingRate(Duration.ofMillis(1))
                 .concurrencyLevel(1)
-                .preferredConcurrencyPollingRateInMilliseconds(-1L)
-                .build());
+                .errorBackoffTime(Duration.ofMillis(2))
+                .build();
+
+        // assert
+        assertThat(retriever.getErrorBackoffTime()).isEqualTo(Duration.ofMillis(2));
     }
 }

--- a/core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
+++ b/core/src/test/java/com/jashmore/sqs/container/CoreMessageListenerContainerTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.sqs.model.Message;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -45,10 +46,10 @@ class CoreMessageListenerContainerTest {
     private static final StaticCoreMessageListenerContainerProperties DEFAULT_PROPERTIES = StaticCoreMessageListenerContainerProperties.builder()
             .shouldInterruptThreadsProcessingMessagesOnShutdown(true)
             .shouldProcessAnyExtraRetrievedMessagesOnShutdown(false)
-            .messageProcessingShutdownTimeoutInSeconds(5)
-            .messageResolverShutdownTimeoutInSeconds(5)
-            .messageRetrieverShutdownTimeoutInSeconds(5)
-            .messageBrokerShutdownTimeoutInSeconds(5)
+            .messageProcessingShutdownTimeout(Duration.ofSeconds(5))
+            .messageResolverShutdownTimeout(Duration.ofSeconds(5))
+            .messageRetrieverShutdownTimeout(Duration.ofSeconds(5))
+            .messageBrokerShutdownTimeout(Duration.ofSeconds(5))
             .build();
 
     @Mock
@@ -420,7 +421,7 @@ class CoreMessageListenerContainerTest {
             return null;
         }).when(messageResolver).run();
         final CoreMessageListenerContainerProperties properties = DEFAULT_PROPERTIES.toBuilder()
-                .messageRetrieverShutdownTimeoutInSeconds(1)
+                .messageRetrieverShutdownTimeout(Duration.ofSeconds(1))
                 .build();
         final CoreMessageListenerContainer container = buildContainer(
                 "id", new StubMessageBroker(), messageResolver, messageProcessor, messageRetriever, properties);

--- a/core/src/test/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolverTest.java
+++ b/core/src/test/java/com/jashmore/sqs/resolver/batching/BatchingMessageResolverTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.Message;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -35,13 +36,13 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class BatchingMessageResolverTest {
-    private static final int BUFFERING_TIME_IN_MS = 1000;
+    private static final Duration BUFFERING_TIME = Duration.ofSeconds(1);
     private static final QueueProperties QUEUE_PROPERTIES = QueueProperties.builder()
             .queueUrl("queueUrl")
             .build();
 
     private static final StaticBatchingMessageResolverProperties DEFAULT_BATCHING_PROPERTIES = StaticBatchingMessageResolverProperties.builder()
-            .bufferingTimeInMs(BUFFERING_TIME_IN_MS)
+            .bufferingTime(BUFFERING_TIME)
             .bufferingSizeLimit(1)
             .build();
 
@@ -65,7 +66,7 @@ class BatchingMessageResolverTest {
         // arrange
         final long bufferingTimeInMs = 100;
         final BatchingMessageResolverProperties batchingProperties = DEFAULT_BATCHING_PROPERTIES.toBuilder()
-                .bufferingTimeInMs(bufferingTimeInMs)
+                .bufferingTime(Duration.ofMillis(bufferingTimeInMs))
                 .bufferingSizeLimit(2)
                 .build();
         final CountDownLatch batchBeingDeletedLatch = new CountDownLatch(1);
@@ -97,7 +98,7 @@ class BatchingMessageResolverTest {
         // arrange
         final long bufferingTimeInMs = 100_000;
         final BatchingMessageResolverProperties batchingProperties = DEFAULT_BATCHING_PROPERTIES.toBuilder()
-                .bufferingTimeInMs(bufferingTimeInMs)
+                .bufferingTime(Duration.ofMillis(bufferingTimeInMs))
                 .bufferingSizeLimit(2)
                 .build();
         final BatchingMessageResolver batchingMessageResolver = new BatchingMessageResolver(QUEUE_PROPERTIES, sqsAsyncClient, batchingProperties);
@@ -125,7 +126,7 @@ class BatchingMessageResolverTest {
         // arrange
         final long bufferingTimeInMs = 100_000;
         final BatchingMessageResolverProperties batchingProperties = DEFAULT_BATCHING_PROPERTIES.toBuilder()
-                .bufferingTimeInMs(bufferingTimeInMs)
+                .bufferingTime(Duration.ofMillis(bufferingTimeInMs))
                 .bufferingSizeLimit(2)
                 .build();
         final BatchingMessageResolver batchingMessageResolver = new BatchingMessageResolver(QUEUE_PROPERTIES, sqsAsyncClient, batchingProperties);
@@ -262,7 +263,7 @@ class BatchingMessageResolverTest {
     void interruptingThreadWhileWaitingForTotalMessageBatchWillStillPublishCurrentMessagesObtained() throws Exception {
         // arrange
         final StaticBatchingMessageResolverProperties batchingProperties = DEFAULT_BATCHING_PROPERTIES.toBuilder()
-                .bufferingTimeInMs(100_000L)
+                .bufferingTime(Duration.ofMillis(100_000L))
                 .bufferingSizeLimit(2)
                 .build();
         final BatchingMessageResolver batchingMessageResolver = new BatchingMessageResolver(QUEUE_PROPERTIES, sqsAsyncClient, batchingProperties);

--- a/core/src/test/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverTest.java
+++ b/core/src/test/java/com/jashmore/sqs/retriever/prefetch/PrefetchingMessageRetrieverTest.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -313,7 +314,7 @@ class PrefetchingMessageRetrieverTest {
         when(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .messageVisibilityTimeoutInSeconds(null)
+                .messageVisibilityTimeout(null)
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -333,7 +334,7 @@ class PrefetchingMessageRetrieverTest {
         when(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .messageVisibilityTimeoutInSeconds(-1)
+                .messageVisibilityTimeout(Duration.ofSeconds(-1))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -353,7 +354,7 @@ class PrefetchingMessageRetrieverTest {
         when(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .messageVisibilityTimeoutInSeconds(-1)
+                .messageVisibilityTimeout(Duration.ZERO)
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -373,7 +374,7 @@ class PrefetchingMessageRetrieverTest {
         when(sqsAsyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .messageVisibilityTimeoutInSeconds(2)
+                .messageVisibilityTimeout(Duration.ofSeconds(2))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -448,7 +449,7 @@ class PrefetchingMessageRetrieverTest {
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final int backoffTimeInMilliseconds = 500;
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .errorBackoffTimeInMilliseconds(backoffTimeInMilliseconds)
+                .errorBackoffTime(Duration.ofMillis(backoffTimeInMilliseconds))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -468,7 +469,7 @@ class PrefetchingMessageRetrieverTest {
                 .thenThrow(new ExpectedTestException());
         final int backoffTimeInMilliseconds = 500;
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .errorBackoffTimeInMilliseconds(backoffTimeInMilliseconds)
+                .errorBackoffTime(Duration.ofMillis(backoffTimeInMilliseconds))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -491,7 +492,7 @@ class PrefetchingMessageRetrieverTest {
                 .thenAnswer(triggerLatchAndReturnMessages(receiveMessageRequested, Message.builder().build()));
         final int backoffTimeInMilliseconds = 500;
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .errorBackoffTimeInMilliseconds(backoffTimeInMilliseconds)
+                .errorBackoffTime(Duration.ofMillis(backoffTimeInMilliseconds))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 
@@ -511,7 +512,7 @@ class PrefetchingMessageRetrieverTest {
                 .thenReturn(CompletableFutureUtils.completedExceptionally(SdkClientException.builder().cause(new SdkInterruptedException()).build()));
         final int backoffTimeInMilliseconds = 500;
         final StaticPrefetchingMessageRetrieverProperties properties = DEFAULT_PREFETCHING_PROPERTIES.toBuilder()
-                .errorBackoffTimeInMilliseconds(backoffTimeInMilliseconds)
+                .errorBackoffTime(Duration.ofMillis(backoffTimeInMilliseconds))
                 .build();
         final PrefetchingMessageRetriever retriever = new PrefetchingMessageRetriever(sqsAsyncClient, QUEUE_PROPERTIES, properties);
 

--- a/core/src/test/java/it/com/jashmore/sqs/listener/concurrent/ConcurrentMessageBrokerIntegrationTest.java
+++ b/core/src/test/java/it/com/jashmore/sqs/listener/concurrent/ConcurrentMessageBrokerIntegrationTest.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -107,7 +108,7 @@ class ConcurrentMessageBrokerIntegrationTest {
                 queueProperties,
                 StaticPrefetchingMessageRetrieverProperties
                         .builder()
-                        .messageVisibilityTimeoutInSeconds(60)
+                        .messageVisibilityTimeout(Duration.ofSeconds(60))
                         .desiredMinPrefetchedMessages(30)
                         .maxPrefetchedMessages(40)
                         .build()
@@ -159,8 +160,8 @@ class ConcurrentMessageBrokerIntegrationTest {
                 elasticMQSqsAsyncClient,
                 StaticBatchingMessageRetrieverProperties.builder()
                         .batchSize(10)
-                        .batchingPeriodInMs(3000L)
-                        .messageVisibilityTimeoutInSeconds(60)
+                        .batchingPeriod(Duration.ofSeconds(3))
+                        .messageVisibilityTimeout(Duration.ofSeconds(60))
                         .build()
         );
         final CountDownLatch messageReceivedLatch = new CountDownLatch(numberOfMessages);

--- a/examples/core-example/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
+++ b/examples/core-example/src/main/java/com/jashmore/sqs/examples/ConcurrentBrokerExample.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.Executors;
@@ -100,13 +101,13 @@ public class ConcurrentBrokerExample {
                     }
 
                     @Override
-                    public @PositiveOrZero Long getConcurrencyPollingRateInMilliseconds() {
-                        return CONCURRENCY_LEVEL_PERIOD_IN_MS;
+                    public Duration getConcurrencyPollingRate() {
+                        return Duration.ofMillis(CONCURRENCY_LEVEL_PERIOD_IN_MS);
                     }
 
                     @Override
-                    public @PositiveOrZero Long getErrorBackoffTimeInMilliseconds() {
-                        return 500L;
+                    public Duration getErrorBackoffTime() {
+                        return Duration.ofMillis(500);
                     }
                 }),
                 () -> new PrefetchingMessageRetriever(
@@ -132,7 +133,7 @@ public class ConcurrentBrokerExample {
                 () -> new BatchingMessageResolver(queueProperties, sqsAsyncClient,
                         StaticBatchingMessageResolverProperties.builder()
                                 .bufferingSizeLimit(1)
-                                .bufferingTimeInMs(5000)
+                                .bufferingTime(Duration.ofSeconds(5))
                                 .build())
         );
         container.start();

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/broker/ConcurrentMessageBrokerDslBuilder.kt
@@ -30,7 +30,7 @@ class ConcurrentMessageBrokerDslBuilder : MessageBrokerDslBuilder {
      * Supplier for getting how long the broker should wait before checking to see if the concurrency rate can be increased if it is
      * already processing the concurrency level limit.
      *
-     * @see [ConcurrentMessageBrokerProperties.getConcurrencyPollingRateInMilliseconds] for in-depth details about this field
+     * @see [ConcurrentMessageBrokerProperties.getConcurrencyPollingRate] for in-depth details about this field
      */
     var concurrencyPollingRate: (() -> Duration?) = { null }
 
@@ -40,7 +40,7 @@ class ConcurrentMessageBrokerDslBuilder : MessageBrokerDslBuilder {
      * This is used to stop it constantly cycling errors and spamming the logs and hopefully the error fixes itself the next time it is
      * attempted.
      *
-     * @see [ConcurrentMessageBrokerProperties.getErrorBackoffTimeInMilliseconds] for in-depth details about this field
+     * @see [ConcurrentMessageBrokerProperties.getErrorBackoffTime] for in-depth details about this field
      */
     var errorBackoffTime: (() -> Duration?) = { null }
 
@@ -48,11 +48,12 @@ class ConcurrentMessageBrokerDslBuilder : MessageBrokerDslBuilder {
         val actualConcurrencyLevel: () -> Int = concurrencyLevel ?: throw RequiredFieldException("concurrencyLevel", "ConcurrentMessageBroker")
         return ConcurrentMessageBroker(
                 object : ConcurrentMessageBrokerProperties {
-                    override fun getErrorBackoffTimeInMilliseconds(): Long? = errorBackoffTime()?.toMillis()
 
                     override fun getConcurrencyLevel(): Int = actualConcurrencyLevel()
 
-                    override fun getConcurrencyPollingRateInMilliseconds(): Long? = concurrencyPollingRate()?.toMillis()
+                    override fun getConcurrencyPollingRate(): Duration? = concurrencyPollingRate()
+
+                    override fun getErrorBackoffTime(): Duration? = errorBackoffTime()
                 }
         )
     }

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/CoreMessageListenerContainerBuilder.kt
@@ -47,19 +47,22 @@ class CoreMessageListenerContainerBuilder(identifier: String, sqsAsyncClient: Sq
                     Supplier(processorBuilder),
                     Supplier(resolverBuilder),
                     object : CoreMessageListenerContainerProperties {
-                        override fun getMessageRetrieverShutdownTimeoutInSeconds(): Int? = shutdown.messageRetrieverShutdownTimeout?.seconds?.toInt()
-
                         override fun shouldInterruptThreadsProcessingMessagesOnShutdown(): Boolean? = shutdown.shouldInterruptThreadsProcessingMessages
-
-                        override fun getMessageResolverShutdownTimeoutInSeconds(): Int? = shutdown.messageResolverShutdownTimeout?.seconds?.toInt()
 
                         override fun shouldProcessAnyExtraRetrievedMessagesOnShutdown(): Boolean? = shutdown.shouldProcessAnyExtraRetrievedMessages
 
-                        override fun getMessageProcessingShutdownTimeoutInSeconds(): Int? = shutdown.messageProcessingShutdownTimeout?.seconds?.toInt()
+                        override fun getMessageBrokerShutdownTimeout(): Duration? = shutdown.messageBrokerShutdownTimeout
+
+                        override fun getMessageProcessingShutdownTimeout(): Duration? = shutdown.messageProcessingShutdownTimeout
+
+                        override fun getMessageResolverShutdownTimeout(): Duration? = shutdown.messageResolverShutdownTimeout
+
+                        override fun getMessageRetrieverShutdownTimeout(): Duration? = shutdown.messageRetrieverShutdownTimeout
                     }
             )
         } else {
-            return CoreMessageListenerContainer(identifier,
+            return CoreMessageListenerContainer(
+                    identifier,
                     Supplier(brokerBuilder),
                     Supplier(retrieverBuilder),
                     Supplier(processorBuilder),
@@ -87,19 +90,19 @@ class ShutdownBuilder {
     /**
      * Set the timeout for how long to wait for the message processing threads to finish.
      *
-     * @see [CoreMessageListenerContainerProperties.getMessageProcessingShutdownTimeoutInSeconds] for more details about this field
+     * @see [CoreMessageListenerContainerProperties.getMessageProcessingShutdownTimeout] for more details about this field
      */
     var messageProcessingShutdownTimeout: Duration? = null
     /**
      * Set the timeout for how long to wait for the [MessageRetriever] background thread to finish.
      *
-     * @see [CoreMessageListenerContainerProperties.getMessageRetrieverShutdownTimeoutInSeconds] for more details about this field
+     * @see [CoreMessageListenerContainerProperties.getMessageRetrieverShutdownTimeout] for more details about this field
      */
     var messageRetrieverShutdownTimeout: Duration? = null
     /**
      * Set the timeout for how to wait for the [MessageResolver] background thread to finish.
      *
-     * @see [CoreMessageListenerContainerProperties.getMessageResolverShutdownTimeoutInSeconds] for more details about this field
+     * @see [CoreMessageListenerContainerProperties.getMessageResolverShutdownTimeout] for more details about this field
      */
     var messageResolverShutdownTimeout: Duration? = null
     /**
@@ -108,7 +111,7 @@ class ShutdownBuilder {
      * Note that if the [ShutdownBuilder.shouldProcessAnyExtraRetrievedMessages] is true and there are extra messages to process, this timeout will
      * be used twice.
      *
-     * @see [CoreMessageListenerContainerProperties.getMessageBrokerShutdownTimeoutInSeconds] for more details about this field
+     * @see [CoreMessageListenerContainerProperties.getMessageBrokerShutdownTimeout] for more details about this field
      */
     var messageBrokerShutdownTimeout: Duration? = null
 }

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/resolver/BatchingMessageResolverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/resolver/BatchingMessageResolverDslBuilder.kt
@@ -19,13 +19,13 @@ class BatchingMessageResolverDslBuilder(private val sqsAsyncClient: SqsAsyncClie
     /**
      * Supplier for getting the buffer size for resolving the messages.
      *
-     * @see [BatchingMessageResolver.getBatchSize] for in-depth details about this field
+     * @see [BatchingMessageResolverProperties.getBufferingSizeLimit] for in-depth details about this field
      */
     var bufferingSizeLimit: (() -> Int)? = null
     /**
      * Supplier for getting the amount of time to wait for the buffer to fill to the limit before sending out any currently buffered messages.
      *
-     * @see [BatchingMessageResolver.getBufferingTimeInMs] for in-depth details about this field
+     * @see [BatchingMessageResolverProperties.getBufferingTime] for in-depth details about this field
      */
     var bufferingTime: (() -> Duration)? = null
 
@@ -39,7 +39,7 @@ class BatchingMessageResolverDslBuilder(private val sqsAsyncClient: SqsAsyncClie
                 object : BatchingMessageResolverProperties {
                     override fun getBufferingSizeLimit(): Int = actualBufferingSizeLimit()
 
-                    override fun getBufferingTimeInMs(): Long = actualBufferingTime().toMillis()
+                    override fun getBufferingTime(): Duration = actualBufferingTime()
                 }
         )
     }

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/BatchingMessageRetrieverDslBuilder.kt
@@ -30,14 +30,14 @@ class BatchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsyncCli
     /**
      * The maximum amount of time to wait for the number of messages requested to reach the [BatchingMessageRetrieverDslBuilder.batchSize].
      *
-     * @see BatchingMessageRetrieverProperties.getBatchingPeriodInMs for more details about this field
+     * @see BatchingMessageRetrieverProperties.getBatchingPeriod for more details about this field
      */
     var batchingPeriod: (() -> Duration)? = null
 
     /**
      * Function for obtaining the visibility timeout for the message being retrieved.
      *
-     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeoutInSeconds for more details about this field
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeout for more details about this field
      */
     var messageVisibility: (() -> Duration?)? = null
 
@@ -60,11 +60,11 @@ class BatchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsyncCli
                 object : BatchingMessageRetrieverProperties {
                     override fun getBatchSize(): Int = actualBatchSize()
 
-                    override fun getBatchingPeriodInMs(): Long = actualBatchingPeriod().toMillis()
+                    override fun getBatchingPeriod(): Duration = actualBatchingPeriod()
 
-                    override fun getMessageVisibilityTimeoutInSeconds(): Int? = actualMessageVisibility()?.seconds?.toInt()
+                    override fun getMessageVisibilityTimeout(): Duration? = actualMessageVisibility()
 
-                    override fun getErrorBackoffTimeInMilliseconds(): Long? = actualErrorBackoffTime()?.toMillis()
+                    override fun getErrorBackoffTime(): Duration? = actualErrorBackoffTime()
                 }
         )
     }

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilder.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/retriever/PrefetchingMessageRetrieverDslBuilder.kt
@@ -34,7 +34,7 @@ class PrefetchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsync
     /**
      * Function for obtaining the visibility timeout for the message being retrieved.
      *
-     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeoutInSeconds for more details about this field
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeout for more details about this field
      */
     var messageVisibility: (() -> Duration?)? = null
 
@@ -59,9 +59,9 @@ class PrefetchingMessageRetrieverDslBuilder(private val sqsAsyncClient: SqsAsync
 
                     override fun getMaxPrefetchedMessages(): Int = actualMaxPrefetched
 
-                    override fun getMessageVisibilityTimeoutInSeconds(): Int? = actualMessageVisibility()?.seconds?.toInt()
+                    override fun getMessageVisibilityTimeout(): Duration? = actualMessageVisibility()
 
-                    override fun getErrorBackoffTimeInMilliseconds(): Int? = actualErrorBackoffTime()?.toMillis()?.toInt()
+                    override fun getErrorBackoffTime(): Duration? = actualErrorBackoffTime()
                 }
         )
     }

--- a/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/QueueListener.java
+++ b/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/QueueListener.java
@@ -131,7 +131,7 @@ public @interface QueueListener {
      * timeout the current threads waiting for messages will have messages requested for them
      *
      * @return the period in ms that threads will wait for messages to be requested from SQS
-     * @see BatchingMessageRetrieverProperties#getBatchingPeriodInMs() for more details
+     * @see BatchingMessageRetrieverProperties#getBatchingPeriod() for more details
      */
     long batchingPeriodInMs() default 2000L;
 
@@ -143,7 +143,7 @@ public @interface QueueListener {
      * <pre>batchingPeriodInMsString = "${my.profile.property}"</pre> instead of having it hardcoded in {@link #batchingPeriodInMs()}.
      *
      * @return the period in ms that threads will wait for messages to be requested from SQS
-     * @see BatchingMessageRetrieverProperties#getBatchingPeriodInMs() for more details
+     * @see BatchingMessageRetrieverProperties#getBatchingPeriod() for more details
      * @see #batchingPeriodInMs() for more information about this field
      */
     String batchingPeriodInMsString() default "";
@@ -152,7 +152,7 @@ public @interface QueueListener {
      * The message visibility that will be used for messages obtained from the queue.
      *
      * @return the message visibility for messages fetched from the queue
-     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeoutInSeconds() for more details and constraints
+     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeout() for more details and constraints
      */
     int messageVisibilityTimeoutInSeconds() default 30;
 
@@ -163,7 +163,7 @@ public @interface QueueListener {
      * <pre>messageVisibilityTimeoutInSeconds = "${my.profile.property}"</pre> instead of having it hardcoded in {@link #messageVisibilityTimeoutInSeconds()}.
      *
      * @return the message visibility for messages fetched from the queue
-     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeoutInSeconds() for more details and constraints
+     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeout() for more details and constraints
      */
     String messageVisibilityTimeoutInSecondsString() default "";
 

--- a/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactory.java
+++ b/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactory.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -123,12 +124,12 @@ public class PrefetchingMessageListenerContainerFactory extends AbstractAnnotati
         return Integer.parseInt(environment.resolvePlaceholders(annotation.maxPrefetchedMessagesString()));
     }
 
-    private int getMessageVisibilityTimeoutInSeconds(final PrefetchingQueueListener annotation) {
+    private Duration getMessageVisibilityTimeout(final PrefetchingQueueListener annotation) {
         if (StringUtils.isEmpty(annotation.messageVisibilityTimeoutInSecondsString())) {
-            return annotation.messageVisibilityTimeoutInSeconds();
+            return Duration.ofSeconds(annotation.messageVisibilityTimeoutInSeconds());
         }
 
-        return Integer.parseInt(environment.resolvePlaceholders(annotation.messageVisibilityTimeoutInSecondsString()));
+        return Duration.ofSeconds(Integer.parseInt(environment.resolvePlaceholders(annotation.messageVisibilityTimeoutInSecondsString())));
     }
 
     private int getDesiredMinPrefetchedMessages(final PrefetchingQueueListener annotation) {
@@ -144,7 +145,7 @@ public class PrefetchingMessageListenerContainerFactory extends AbstractAnnotati
         return StaticPrefetchingMessageRetrieverProperties.builder()
                 .desiredMinPrefetchedMessages(getDesiredMinPrefetchedMessages(annotation))
                 .maxPrefetchedMessages(getMaxPrefetchedMessages(annotation))
-                .messageVisibilityTimeoutInSeconds(getMessageVisibilityTimeoutInSeconds(annotation))
+                .messageVisibilityTimeout(getMessageVisibilityTimeout(annotation))
                 .build();
     }
 

--- a/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingQueueListener.java
+++ b/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingQueueListener.java
@@ -143,7 +143,7 @@ public @interface PrefetchingQueueListener {
      * The message visibility that will be used for messages obtained from the queue.
      *
      * @return the message visibility for messages fetched from the queue
-     * @see StaticPrefetchingMessageRetrieverProperties#getMessageVisibilityTimeoutInSeconds() for more details and constraints
+     * @see StaticPrefetchingMessageRetrieverProperties#getMessageVisibilityTimeout() for more details and constraints
      */
     int messageVisibilityTimeoutInSeconds() default 30;
 
@@ -154,7 +154,7 @@ public @interface PrefetchingQueueListener {
      * <pre>messageVisibilityTimeoutInSeconds = "${my.profile.property}"</pre> instead of having it hardcoded in {@link #messageVisibilityTimeoutInSeconds()}.
      *
      * @return the message visibility for messages fetched from the queue
-     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeoutInSeconds() for more details and constraints
+     * @see BatchingMessageRetrieverProperties#getMessageVisibilityTimeout() for more details and constraints
      */
     String messageVisibilityTimeoutInSecondsString() default "";
 

--- a/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/basic/BasicMessageListenerContainerFactoryTest.java
+++ b/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/basic/BasicMessageListenerContainerFactoryTest.java
@@ -26,6 +26,7 @@ import org.springframework.core.env.Environment;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -184,8 +185,8 @@ class BasicMessageListenerContainerFactoryTest {
 
         // assert
         assertThat(properties).isEqualTo(StaticBatchingMessageRetrieverProperties.builder()
-                .messageVisibilityTimeoutInSeconds(300)
-                .batchingPeriodInMs(40L)
+                .messageVisibilityTimeout(Duration.ofSeconds(300))
+                .batchingPeriod(Duration.ofMillis(40L))
                 .batchSize(10)
                 .build()
         );
@@ -206,8 +207,8 @@ class BasicMessageListenerContainerFactoryTest {
 
         // assert
         assertThat(properties).isEqualTo(StaticBatchingMessageRetrieverProperties.builder()
-                .messageVisibilityTimeoutInSeconds(40)
-                .batchingPeriodInMs(30L)
+                .messageVisibilityTimeout(Duration.ofSeconds(40))
+                .batchingPeriod(Duration.ofMillis(30))
                 .batchSize(8)
                 .build()
         );

--- a/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactoryTest.java
+++ b/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingMessageListenerContainerFactoryTest.java
@@ -26,6 +26,7 @@ import org.springframework.core.env.Environment;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -203,7 +204,7 @@ class PrefetchingMessageListenerContainerFactoryTest {
         assertThat(properties).isEqualTo(StaticPrefetchingMessageRetrieverProperties.builder()
                 .maxPrefetchedMessages(30)
                 .desiredMinPrefetchedMessages(40)
-                .messageVisibilityTimeoutInSeconds(40)
+                .messageVisibilityTimeout(Duration.ofSeconds(40))
                 .build()
         );
     }
@@ -221,7 +222,7 @@ class PrefetchingMessageListenerContainerFactoryTest {
         assertThat(properties).isEqualTo(StaticPrefetchingMessageRetrieverProperties.builder()
                 .maxPrefetchedMessages(20)
                 .desiredMinPrefetchedMessages(5)
-                .messageVisibilityTimeoutInSeconds(300)
+                .messageVisibilityTimeout(Duration.ofSeconds(300))
                 .build()
         );
     }

--- a/util/common-utils/src/main/java/com/jashmore/sqs/util/properties/PropertyUtils.java
+++ b/util/common-utils/src/main/java/com/jashmore/sqs/util/properties/PropertyUtils.java
@@ -3,6 +3,7 @@ package com.jashmore.sqs.util.properties;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -84,6 +85,20 @@ public class PropertyUtils {
      */
     public int safelyGetPositiveOrZeroIntegerValue(final String propertyName, final Supplier<Integer> valueSupplier, final int defaultValue) {
         return safelyGetValue(propertyName, valueSupplier, defaultValue, aInteger -> aInteger >= 0);
+    }
+
+    /**
+     * Get the duration from a property and if it is null or negative, return the default value supplied.
+     *
+     * @param propertyName  the name of the property
+     * @param valueSupplier the supplier to get the property value
+     * @param defaultValue  the default duration
+     * @return the duration for the property
+     */
+    public Duration safelyGetPositiveOrZeroDuration(final String propertyName,
+                                                    final Supplier<Duration> valueSupplier,
+                                                    final Duration defaultValue) {
+        return safelyGetValue(propertyName, valueSupplier, defaultValue, (duration) -> !duration.isNegative());
     }
 
     private <T> T safelyGetValue(final String propertyName,

--- a/util/common-utils/src/test/java/com/jashmore/sqs/util/properties/PropertyUtilsTest.java
+++ b/util/common-utils/src/test/java/com/jashmore/sqs/util/properties/PropertyUtilsTest.java
@@ -1,9 +1,13 @@
 package com.jashmore.sqs.util.properties;
 
+import static com.jashmore.sqs.util.properties.PropertyUtils.safelyGetPositiveOrZeroDuration;
+import static com.jashmore.sqs.util.properties.PropertyUtils.safelyGetPositiveOrZeroIntegerValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jashmore.sqs.util.ExpectedTestException;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 
 class PropertyUtilsTest {
 
@@ -60,12 +64,24 @@ class PropertyUtilsTest {
 
     @Test
     void testSafelyGetPositiveOrZeroIntegerValue() {
-        assertThat(PropertyUtils.safelyGetPositiveOrZeroIntegerValue("prop", () -> 1, 5)).isEqualTo(1);
-        assertThat(PropertyUtils.safelyGetPositiveOrZeroIntegerValue("prop", () -> -1, 5)).isEqualTo(5);
-        assertThat(PropertyUtils.safelyGetPositiveOrZeroIntegerValue("prop", () -> 0, 5)).isEqualTo(0);
-        assertThat(PropertyUtils.safelyGetPositiveOrZeroIntegerValue("prop", () -> null, 5)).isEqualTo(5);
-        assertThat(PropertyUtils.safelyGetPositiveOrZeroIntegerValue("prop", () -> {
+        assertThat(safelyGetPositiveOrZeroIntegerValue("prop", () -> 1, 5)).isEqualTo(1);
+        assertThat(safelyGetPositiveOrZeroIntegerValue("prop", () -> -1, 5)).isEqualTo(5);
+        assertThat(safelyGetPositiveOrZeroIntegerValue("prop", () -> 0, 5)).isEqualTo(0);
+        assertThat(safelyGetPositiveOrZeroIntegerValue("prop", () -> null, 5)).isEqualTo(5);
+        assertThat(safelyGetPositiveOrZeroIntegerValue("prop", () -> {
             throw new ExpectedTestException();
         }, 5)).isEqualTo(5);
+    }
+
+    @Test
+    void getPositiveOrZeroDuration() {
+        final Duration defaultDuration = Duration.ofSeconds(5);
+        assertThat(safelyGetPositiveOrZeroDuration("prop", () -> Duration.ofSeconds(1), defaultDuration)).isEqualTo(Duration.ofSeconds(1));
+        assertThat(safelyGetPositiveOrZeroDuration("prop", () -> Duration.ofSeconds(-1), defaultDuration)).isEqualTo(defaultDuration);
+        assertThat(safelyGetPositiveOrZeroDuration("prop", () -> Duration.ofSeconds(0), defaultDuration)).isEqualTo(Duration.ofSeconds(0));
+        assertThat(safelyGetPositiveOrZeroDuration("prop", () -> null, defaultDuration)).isEqualTo(defaultDuration);
+        assertThat(safelyGetPositiveOrZeroDuration("prop", () -> {
+            throw new ExpectedTestException();
+        }, defaultDuration)).isEqualTo(defaultDuration);
     }
 }


### PR DESCRIPTION
This converts a lot of properties from property values like timeoutInSeconds
as timeout using the Java duration type. This makes the code easier to read
and reduces errors in submitting the wrong values.