### PR TITLE
refs #259: Add batching and prefetching queue listeners into Kotlin DSL

### DIFF
--- a/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
+++ b/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
@@ -67,6 +67,46 @@ val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
 }
 ```
 
+## Using the batchingMessageListener
+
+This is equivalent to
+the [@QueueListener](../../../spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/basic/QueueListener.java) annotation
+used in a Spring Boot application which will set up a container that will request for messages in batches.
+
+```kotlin
+batchingMessageListener("identifier", sqsAsyncClient, "url") {
+    concurrencyLevel = { 10 }
+    batchSize = { 5 }
+    batchingPeriod =  { Duration.ofSeconds(5) }
+
+    processor = lambdaProcessor {
+        method { message ->
+            log.info("Message: {}", message.body())
+        }
+    }
+}
+```
+
+## Using the prefetchingMessageListener
+
+This is equivalent to
+the [@PrefetchingQueueListener](../../../spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/prefetch/PrefetchingQueueListener.java) annotation
+used in a Spring Boot application which will set up a container that will prefetch messages for processing.
+
+```kotlin
+prefetchingMessageListener("identifier", sqsAsyncClient, "url") {
+    concurrencyLevel = { 2 }
+    desiredPrefetchedMessages = 5
+    maxPrefetchedMessages = 10
+
+    processor = lambdaProcessor {
+        method { message ->
+            log.info("Message: {}", message.body())
+        }
+    }
+}
+```
+
 ## Example
 
 A full example of using the Kotlin DSL can be found in the [core-kotlin-example](../../../examples/core-kotlin-example/README.md).

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/BatchingMessageListenerContainerBuilderDsl.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/BatchingMessageListenerContainerBuilderDsl.kt
@@ -1,0 +1,148 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties
+import com.jashmore.sqs.container.CoreMessageListenerContainer
+import com.jashmore.sqs.container.CoreMessageListenerContainerProperties
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.retriever.BatchingMessageRetrieverDslBuilder
+import com.jashmore.sqs.resolver.batching.BatchingMessageResolverProperties
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.retriever.batching.BatchingMessageRetrieverProperties
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetrieverProperties
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+
+@MessageListenerComponentDslMarker
+class BatchingMessageListenerContainerBuilder(identifier: String,
+                                              sqsAsyncClient: SqsAsyncClient,
+                                              queueProperties: QueueProperties) : MessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties) {
+    /**
+     * Supplier for getting the number of messages that should be processed concurrently.
+     *
+     * Each time a new message is begun to be processed this supplier will be checked and therefore it should be optimised via caching
+     * or another method. This field may return different values each time it is checked and therefore the rate of concurrency can
+     * be dynamically changed during runtime.
+     *
+     * @see [ConcurrentMessageBrokerProperties.getConcurrencyLevel] for in-depth details about this field
+     */
+    var concurrencyLevel: (() -> Int)? = null
+    /**
+     * The batch size for the number of messages to receive at once
+     *
+     * @see BatchingMessageRetrieverProperties.getBatchSize for more details about this field
+     * @see BatchingMessageResolverProperties.getBufferingSizeLimit for more details about this field
+     */
+    var batchSize: (() -> Int) = { 5 }
+    /**
+     * The maximum amount of time to wait for the number of messages requested to reach the [BatchingMessageRetrieverDslBuilder.batchSize].
+     *
+     * @see BatchingMessageRetrieverProperties.getBatchingPeriod for more details about this field
+     * @see BatchingMessageResolverProperties.getBufferingTime for more details about this field
+     */
+    var batchingPeriod: (() -> Duration) = { Duration.ofSeconds(2) }
+    /**
+     * Function for obtaining the visibility timeout for the message being retrieved.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeout for more details about this field
+     */
+    var messageVisibility: (() -> Duration?) = { Duration.ofSeconds(30) }
+    /**
+     * Set whether any extra messages that may have been internally stored in the [MessageRetriever] should be processed before shutting down.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldProcessAnyExtraRetrievedMessagesOnShutdown] for more details about this field
+     */
+    var processExtraMessagesOnShutdown: Boolean = true
+    /**
+     * Set whether the message processing threads should be interrupted when a shutdown is requested.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldInterruptThreadsProcessingMessagesOnShutdown] for more details about this field
+     */
+    var interruptThreadsProcessingMessagesOnShutdown: Boolean = false
+
+    override fun invoke(): MessageListenerContainer {
+        return coreMessageListener(identifier, sqsAsyncClient, queueProperties) {
+            processor = this@BatchingMessageListenerContainerBuilder.processor
+            broker = concurrentBroker {
+                concurrencyLevel = this@BatchingMessageListenerContainerBuilder.concurrencyLevel
+            }
+            retriever = batchingMessageRetriever {
+                batchSize = this@BatchingMessageListenerContainerBuilder.batchSize
+                batchingPeriod = this@BatchingMessageListenerContainerBuilder.batchingPeriod
+                messageVisibility = this@BatchingMessageListenerContainerBuilder.messageVisibility
+            }
+            resolver = batchingResolver {
+                batchSize = this@BatchingMessageListenerContainerBuilder.batchSize
+                batchingPeriod = this@BatchingMessageListenerContainerBuilder.batchingPeriod
+            }
+            shutdown {
+                shouldInterruptThreadsProcessingMessages = this@BatchingMessageListenerContainerBuilder.interruptThreadsProcessingMessagesOnShutdown
+                shouldProcessAnyExtraRetrievedMessages = this@BatchingMessageListenerContainerBuilder.processExtraMessagesOnShutdown
+            }
+        }
+    }
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL that will batch requests to retrieve messages to process.
+ *
+ * This is equivalent to the @QueueListener annotation in the Spring implementation.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = batchingMessageListener("identifier", sqsAsyncClient, "url") {
+ *      concurrencyLevel = { 2 }
+ *      batchSize = { 5 }
+ *      batchingPeriod = { Duration.ofSeconds(2) }
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier      the identifier that uniquely identifies this container
+ * @param sqsAsyncClient  the client for communicating with the SQS server
+ * @param queueUrl        the URL of the queue to listen to this
+ * @param init            the function to configure this container
+ * @return the message listener container
+ */
+fun batchingMessageListener(identifier: String,
+                            sqsAsyncClient: SqsAsyncClient,
+                            queueUrl: String,
+                            init: BatchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return batchingMessageListener(identifier, sqsAsyncClient, QueueProperties.builder().queueUrl(queueUrl).build(), init)
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL that will batch requests to retrieve messages to process.
+ *
+ * This is equivalent to the @QueueListener annotation in the Spring implementation.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = batchingMessageListener("identifier", sqsAsyncClient, QueueProperties.builder().queueUrl("url").build()) {
+ *      concurrencyLevel = { 2 }
+ *      batchSize = { 5 }
+ *      batchingPeriod = { Duration.ofSeconds(2) }
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier      the identifier that uniquely identifies this container
+ * @param sqsAsyncClient  the client for communicating with the SQS server
+ * @param queueProperties details about the queue that is being listened to
+ * @param init            the function to configure this container
+ * @return the message listener container
+ */
+fun batchingMessageListener(identifier: String,
+                            sqsAsyncClient: SqsAsyncClient,
+                            queueProperties: QueueProperties,
+                            init: BatchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+
+    val listener = BatchingMessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties)
+    listener.init()
+    return listener()
+}

--- a/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/PrefetchingMessageListenerContainerBuilderDsl.kt
+++ b/extensions/core-kotlin-dsl/src/main/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/PrefetchingMessageListenerContainerBuilderDsl.kt
@@ -1,0 +1,141 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.QueueProperties
+import com.jashmore.sqs.broker.concurrent.ConcurrentMessageBrokerProperties
+import com.jashmore.sqs.container.CoreMessageListenerContainer
+import com.jashmore.sqs.container.CoreMessageListenerContainerProperties
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.core.kotlin.dsl.MessageListenerComponentDslMarker
+import com.jashmore.sqs.core.kotlin.dsl.retriever.PrefetchingMessageRetrieverDslBuilder
+import com.jashmore.sqs.retriever.MessageRetriever
+import com.jashmore.sqs.retriever.prefetch.PrefetchingMessageRetrieverProperties
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import java.time.Duration
+
+@MessageListenerComponentDslMarker
+class PrefetchingMessageListenerContainerBuilder(identifier: String,
+                                                 sqsAsyncClient: SqsAsyncClient,
+                                                 queueProperties: QueueProperties) : MessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties) {
+    /**
+     * Supplier for getting the number of messages that should be processed concurrently.
+     *
+     * Each time a new message is begun to be processed this supplier will be checked and therefore it should be optimised via caching
+     * or another method. This field may return different values each time it is checked and therefore the rate of concurrency can
+     * be dynamically changed during runtime.
+     *
+     * @see [ConcurrentMessageBrokerProperties.getConcurrencyLevel] for in-depth details about this field
+     */
+    var concurrencyLevel: (() -> Int)? = null
+    /**
+     * The desired messages to be prefetched.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getDesiredMinPrefetchedMessages for more details about this field
+     */
+    var desiredPrefetchedMessages: Int? = null
+    /**
+     * The maximum numbers that can be prefetched, must be less than [PrefetchingMessageRetrieverDslBuilder.desiredPrefetchedMessages].
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMaxPrefetchedMessages for more details about this field
+     */
+    var maxPrefetchedMessages: Int? = null
+    /**
+     * Function for obtaining the visibility timeout for the message being retrieved.
+     *
+     * @see PrefetchingMessageRetrieverProperties.getMessageVisibilityTimeout for more details about this field
+     */
+    var messageVisibility: (() -> Duration?) = { Duration.ofSeconds(30) }
+    /**
+     * Set whether any extra messages that may have been internally stored in the [MessageRetriever] should be processed before shutting down.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldProcessAnyExtraRetrievedMessagesOnShutdown] for more details about this field
+     */
+    var processExtraMessagesOnShutdown: Boolean = true
+    /**
+     * Set whether the message processing threads should be interrupted when a shutdown is requested.
+     *
+     * @see [CoreMessageListenerContainerProperties.shouldInterruptThreadsProcessingMessagesOnShutdown] for more details about this field
+     */
+    var interruptThreadsProcessingMessagesOnShutdown: Boolean = false
+
+    override fun invoke(): MessageListenerContainer {
+        return coreMessageListener(identifier, sqsAsyncClient, queueProperties) {
+            processor = this@PrefetchingMessageListenerContainerBuilder.processor
+            broker = concurrentBroker {
+                concurrencyLevel = this@PrefetchingMessageListenerContainerBuilder.concurrencyLevel
+            }
+            retriever = prefetchingMessageRetriever {
+                desiredPrefetchedMessages = this@PrefetchingMessageListenerContainerBuilder.desiredPrefetchedMessages
+                maxPrefetchedMessages = this@PrefetchingMessageListenerContainerBuilder.maxPrefetchedMessages
+                messageVisibility = this@PrefetchingMessageListenerContainerBuilder.messageVisibility
+            }
+            resolver = batchingResolver()
+            shutdown {
+                shouldInterruptThreadsProcessingMessages = this@PrefetchingMessageListenerContainerBuilder.interruptThreadsProcessingMessagesOnShutdown
+                shouldProcessAnyExtraRetrievedMessages = this@PrefetchingMessageListenerContainerBuilder.processExtraMessagesOnShutdown
+            }
+        }
+    }
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL that will prefetch messages to process.
+ *
+ * This is equivalent to the @PrefetchingQueueListener annotation in the Spring implementation.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = prefetchingMessageListener("identifier", sqsAsyncClient, "url") {
+ *      concurrencyLevel = { 2 }
+ *      desiredPrefetchedMessages = 5
+ *      maxPrefetchedMessages = 10
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier      the identifier that uniquely identifies this container
+ * @param sqsAsyncClient  the client for communicating with the SQS server
+ * @param queueUrl        the URL of the queue to listen to this
+ * @param init            the function to configure this container
+ * @return the message listener container
+ */
+fun prefetchingMessageListener(identifier: String,
+                               sqsAsyncClient: SqsAsyncClient,
+                               queueUrl: String,
+                               init: PrefetchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return prefetchingMessageListener(identifier, sqsAsyncClient, QueueProperties.builder().queueUrl(queueUrl).build(), init)
+}
+
+/**
+ * Build a [CoreMessageListenerContainer] using a Kotlin DSL that will prefetch messages to process.
+ *
+ * This is equivalent to the @PrefetchingMessageListener annotation in the Spring implementation.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val container = prefetchingMessageListener("identifier", sqsAsyncClient, QueueProperties.builder().queueUrl("url").build()) {
+ *      concurrencyLevel = { 2 }
+ *      desiredPrefetchedMessages = 5
+ *      maxPrefetchedMessages = 10
+ *
+ *      // other configurations here...
+ * }
+ * ```
+ *
+ * @param identifier      the identifier that uniquely identifies this container
+ * @param sqsAsyncClient  the client for communicating with the SQS server
+ * @param queueProperties details about the queue that is being listened to
+ * @param init            the function to configure this container
+ * @return the message listener container
+ */
+fun prefetchingMessageListener(identifier: String,
+                               sqsAsyncClient: SqsAsyncClient,
+                               queueProperties: QueueProperties,
+                               init: PrefetchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+
+    val listener = PrefetchingMessageListenerContainerBuilder(identifier, sqsAsyncClient, queueProperties)
+    listener.init()
+    return listener()
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/BatchingMessageListenerContainerBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/BatchingMessageListenerContainerBuilderTest.kt
@@ -1,0 +1,45 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class BatchingMessageListenerContainerBuilderTest {
+
+    var container: MessageListenerContainer? = null
+
+    @AfterEach
+    internal fun tearDown() {
+        container?.stop()
+    }
+
+    @Test
+    fun `minimal configuration`() {
+        // arrange
+        val sqsAsyncClient = ElasticMqSqsAsyncClient()
+        val queueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+
+        // act
+        container = batchingMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            concurrencyLevel = { 1 }
+            batchSize = { 5 }
+            batchingPeriod = { Duration.ofSeconds(1) }
+            processor = lambdaProcessor {
+                method { _ ->
+                    countDownLatch.countDown()
+                }
+            }
+        }
+        container?.start()
+        sqsAsyncClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }
+
+        // assert
+        Assertions.assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+}

--- a/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/PrefetchingMessageListenerContainerBuilderTest.kt
+++ b/extensions/core-kotlin-dsl/src/test/kotlin/com/jashmore/sqs/core/kotlin/dsl/container/PrefetchingMessageListenerContainerBuilderTest.kt
@@ -1,0 +1,45 @@
+package com.jashmore.sqs.core.kotlin.dsl.container
+
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class PrefetchingMessageListenerContainerBuilderTest {
+
+    var container: MessageListenerContainer? = null
+
+    @AfterEach
+    internal fun tearDown() {
+        container?.stop()
+    }
+
+    @Test
+    fun `minimal configuration`() {
+        // arrange
+        val sqsAsyncClient = ElasticMqSqsAsyncClient()
+        val queueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+
+        // act
+        container = prefetchingMessageListener("identifier", sqsAsyncClient, queueUrl) {
+            concurrencyLevel = { 1 }
+            desiredPrefetchedMessages = 5
+            maxPrefetchedMessages = 10
+            processor = lambdaProcessor {
+                method { _ ->
+                    countDownLatch.countDown()
+                }
+            }
+        }
+        container?.start()
+        sqsAsyncClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }
+
+        // assert
+        Assertions.assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+}


### PR DESCRIPTION
This adds the ability to create the equivalent containers as the
@QueueListener and @PrefetchingQueueListener in the Kotlin Core DSL.

For example:

```kotlin
val container = batchingMessageListener("identifier", sqsAsyncClient,
"url") {
    concurrencyLevel = { 10 }
    batchSize = { 5 }
    batchingPeriod =  { Duration.ofSeconds(5) }

    processor = lambdaProcessor {
        method { message ->
            log.info("Message: {}", message.body())
        }
    }
}
```

or

```kotlin
val container = prefetchingMessageListener("identifier", sqsAsyncClient,
"url") {
    concurrencyLevel = { 2 }
    desiredPrefetchedMessages = 5
    maxPrefetchedMessages = 10

    processor = lambdaProcessor {
        method { message ->
            log.info("Message: {}", message.body())
        }
    }
}
```