### PR TITLE
refs #254: Added Ktor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ See the [build.gradle.kts](build.gradle.kts) for the specific versions of these 
     across multiple AWS Accounts
     1. [How to version message payload schemas](doc/how-to-guides/spring/spring-how-to-version-payload-schemas-using-spring-cloud-schema-registry.md): guide
     for versioning payloads using Avro and the Spring Cloud Schema Registry.
+1. Ktor How to Guides
+    1. [How to Register Message Listeners](doc/how-to-guides/ktor/ktor-how-to-register-message-listeners.md): guide for include message listeners into a
+    Ktor application.
 
 ## Common Use Cases/Explanations
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ allprojects {
 }
 
 subprojects {
-    val isKotlinProject = project.name.contains("kotlin")
+    val isKotlinProject = project.name.contains("kotlin") || project.name.contains("ktor")
     apply(plugin = "java-library")
     apply(plugin = "jacoco")
     if (!isKotlinProject) {

--- a/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
+++ b/doc/how-to-guides/core/core-how-to-use-kotlin-dsl.md
@@ -59,7 +59,7 @@ Check out the [Core Kotlin DSL](../../../extensions/core-kotlin-dsl) for more de
 ```kotlin
 val container = coreMessageListener("identifier", sqsAsyncClient, queueUrl) {
     processor = lambdaProcessor {
-        method { message -> 
+        method { message ->
             log.info("Message received: {}", message.body())
         }
     }
@@ -74,7 +74,7 @@ the [@QueueListener](../../../spring/spring-core/src/main/java/com/jashmore/sqs/
 used in a Spring Boot application which will set up a container that will request for messages in batches.
 
 ```kotlin
-batchingMessageListener("identifier", sqsAsyncClient, "url") {
+val container = batchingMessageListener("identifier", sqsAsyncClient, "url") {
     concurrencyLevel = { 10 }
     batchSize = { 5 }
     batchingPeriod =  { Duration.ofSeconds(5) }
@@ -94,7 +94,7 @@ the [@PrefetchingQueueListener](../../../spring/spring-core/src/main/java/com/ja
 used in a Spring Boot application which will set up a container that will prefetch messages for processing.
 
 ```kotlin
-prefetchingMessageListener("identifier", sqsAsyncClient, "url") {
+val container = prefetchingMessageListener("identifier", sqsAsyncClient, "url") {
     concurrencyLevel = { 2 }
     desiredPrefetchedMessages = 5
     maxPrefetchedMessages = 10

--- a/doc/how-to-guides/ktor/ktor-how-to-register-message-listeners.md
+++ b/doc/how-to-guides/ktor/ktor-how-to-register-message-listeners.md
@@ -1,0 +1,56 @@
+# Ktor - How to Register Message Listeners
+
+The [Ktor Core](../../../ktor/core) module adds the ability to register Message Listeners into the web application.
+
+## Steps
+
+1. Include the [Ktor Core](../../../ktor/core) dependency.
+
+    ```xml
+    <dependency>
+        <groupId>com.jashmore</groupId>
+        <artifactId>java-dynamic-sqs-listener-ktor-core</artifactId>
+        <version>${dynamic-sqs-listener.version}</version>
+    </dependency>
+    ```
+
+1. Include one of the message listener [extension functions](../../../ktor/core/src/main/kotlin/com/jashmore/sqs/ktor/container/KtorCoreExtension.kt) imports.
+
+    ```kotlin
+    import com.jashmore.sqs.ktor.container.* // Change * to the specific function
+    ```
+
+    Make sure to use this `ktor` import instead of the `com.jashmore.sqs.core.kotlin.dsl.container.*` import as the `ktor` version will attach
+    to the lifecycle of the server.
+
+1. Integrate the message listener into the web application
+
+    ```kotlin
+    val server = embeddedServer(Netty, 8080) {
+        batchingMessageListener("batching-listener", sqsAsyncClient, queeuUrl) {
+            concurrencyLevel = { 2 }
+
+            processor = lambdaProcessor {
+                method { message ->
+                    log.info("Processing message: ${message.body()}")
+                }
+            }
+        }
+    }
+    ```
+
+## Shutting down the container on server shutdown
+
+To make sure the message listener is gracefully shutdown when the web server is shutdown, you will need to make sure to
+attach to a `ShutdownHook`:
+
+```kotlin
+    val server = embeddedServer(Netty, 8080) {
+       // setup message listeners here
+    }
+    server.start()
+    Runtime.getRuntime().addShutdownHook(Thread {
+        server.stop(1, 30_000)
+    })
+    Thread.currentThread().join()
+```

--- a/examples/ktor-example/README.md
+++ b/examples/ktor-example/README.md
@@ -1,0 +1,15 @@
+# Ktor Example
+
+This example shows the usage of the [Ktor Core](../../ktor/core) module which uses the [Core Kotlin DSL](../../extensions/core-kotlin-dsl) to build
+the message listeners. It creates multiple message listeners that use different methods to process messages, such as prefetching messages, etc.
+
+## Usage
+
+```bash
+gradle runApp
+```
+
+Perform a GET request to [http://localhost:8080/message/{queueIdentifier}](http://localhost:8080/message/one) where the queueIdentifier is one
+of `one`, `two`, or `three`. Any unknown queue will return 404. You can also start and stop the message listeners by navigating to
+[http://localhost:8080/start/{queueIdentifier}](http://localhost:8080/start/one) and
+[http://localhost:8080/stop/{queueIdentifier}](http://localhost:8080/stop/one) respectively.

--- a/examples/ktor-example/build.gradle.kts
+++ b/examples/ktor-example/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+description = "Contains examples for connection to SQS in an Ktor Application"
+
+plugins {
+    kotlin("jvm") version "1.3.72"
+}
+
+repositories {
+    jcenter()
+}
+
+apply(plugin = "kotlin")
+
+dependencies {
+    implementation(project(":java-dynamic-sqs-listener-core"))
+    implementation(project(":core-kotlin-dsl"))
+    implementation(project(":elasticmq-sqs-client"))
+    api(project(":java-dynamic-sqs-listener-ktor-core"))
+    implementation("io.ktor:ktor-server-netty:1.3.2")
+    implementation("ch.qos.logback:logback-core")
+    implementation("ch.qos.logback:logback-classic")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+tasks.create<JavaExec>("runApp") {
+    classpath = sourceSets.main.get().runtimeClasspath
+
+    main = "com.jashmore.sqs.examples.KtorApplicationExample"
+}

--- a/examples/ktor-example/src/main/kotlin/com/jashmore/sqs/examples/KtorApplicationExample.kt
+++ b/examples/ktor-example/src/main/kotlin/com/jashmore/sqs/examples/KtorApplicationExample.kt
@@ -1,0 +1,152 @@
+@file:JvmName("KtorApplicationExample")
+package com.jashmore.sqs.examples
+
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import com.jashmore.sqs.ktor.container.batchingMessageListener
+import com.jashmore.sqs.ktor.container.messageListener
+import com.jashmore.sqs.ktor.container.prefetchingMessageListener
+import io.ktor.application.call
+import io.ktor.application.log
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.response.respond
+import io.ktor.response.respondText
+import io.ktor.routing.get
+import io.ktor.routing.routing
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+import kotlinx.coroutines.launch
+import software.amazon.awssdk.services.sqs.model.Message
+import java.time.Duration
+
+fun main() {
+    val sqsAsyncClient = ElasticMqSqsAsyncClient()
+
+    val server = embeddedServer(Netty, 8080) {
+        val firstQueueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val firstContainer = messageListener("core-listener", sqsAsyncClient, firstQueueUrl) {
+            processor = lambdaProcessor {
+                method { message ->
+                    log.info("Message: {}", message.body())
+                }
+            }
+            retriever = batchingMessageRetriever {
+                batchSize = { 1 }
+                batchingPeriod = { Duration.ofSeconds(30) }
+            }
+            resolver = batchingResolver {
+                batchSize = { 1 }
+                batchingPeriod = { Duration.ofSeconds(5) }
+            }
+            broker = concurrentBroker {
+                concurrencyLevel = { 5 }
+                concurrencyPollingRate = { Duration.ofMinutes(1) }
+            }
+        }
+
+        val secondQueueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val secondContainer = prefetchingMessageListener("prefetching-listener", sqsAsyncClient, secondQueueUrl) {
+            concurrencyLevel = { 2 }
+            desiredPrefetchedMessages = 5
+            maxPrefetchedMessages = 10
+
+            processor = lambdaProcessor {
+                methodWithVisibilityExtender { message, _ ->
+                    log.info("Message: {}", message.body())
+                }
+            }
+        }
+
+        val thirdQueueUrl = sqsAsyncClient.createRandomQueue().get().queueUrl()
+        val thirdContainer = batchingMessageListener("batching-listener", sqsAsyncClient, thirdQueueUrl) {
+            concurrencyLevel = { 2 }
+            batchSize = { 5 }
+            batchingPeriod =  { Duration.ofSeconds(5) }
+
+            processor = asyncLambdaProcessor {
+                method { message ->
+                    log.info("Processing message: ${message.body()}")
+                    future {
+                        something(message)
+                    }
+                }
+            }
+        }
+
+        routing {
+            get("/message/{queue}") {
+                val queueIdentifier = call.parameters["queue"]
+                val queueUrl: String? = when (queueIdentifier) {
+                    "one" -> firstQueueUrl
+                    "two" -> secondQueueUrl
+                    "three" -> thirdQueueUrl
+                    else -> null
+                }
+
+                if (queueUrl == null) {
+                    call.respond(HttpStatusCode.NotFound, "Unknown queue: $queueIdentifier")
+                    return@get
+                }
+
+                val response = sqsAsyncClient.sendMessage {
+                    it.queueUrl(queueUrl).messageBody("body")
+                }.await()
+
+                call.respondText("Hello, world! ${response.messageId()}", ContentType.Text.Html)
+            }
+
+            get("/start/{queue}") {
+                val queueIdentifier = call.parameters["queue"]
+                val container: MessageListenerContainer? = when (queueIdentifier) {
+                    "one" -> firstContainer
+                    "two" -> secondContainer
+                    "three" -> thirdContainer
+                    else -> null
+                }
+
+                if (container == null) {
+                    call.respond(HttpStatusCode.NotFound, "Unknown queue: $queueIdentifier")
+                    return@get
+                }
+
+                container.start()
+
+                call.respondText("Container ${queueIdentifier} started", ContentType.Text.Html)
+            }
+
+
+            get("/stop/{queue}") {
+                val queueIdentifier = call.parameters["queue"]
+                val container: MessageListenerContainer? = when (queueIdentifier) {
+                    "one" -> firstContainer
+                    "two" -> secondContainer
+                    "three" -> thirdContainer
+                    else -> null
+                }
+
+                if (container == null) {
+                    call.respond(HttpStatusCode.NotFound, "Unknown queue: $queueIdentifier")
+                    return@get
+                }
+
+                container.stop()
+
+                call.respondText("Container ${queueIdentifier} stopped", ContentType.Text.Html)
+            }
+        }
+    }
+    server.start()
+    Runtime.getRuntime().addShutdownHook(Thread {
+        server.stop(1, 30_000)
+    })
+    Thread.currentThread().join()
+}
+
+suspend fun something(@Suppress("UNUSED_PARAMETER") message: Message) = GlobalScope.launch {
+    delay(5000)
+}

--- a/examples/ktor-example/src/main/resources/logback.xml
+++ b/examples/ktor-example/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg %yellow(%mdc) %n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- We reduce the log messages from ElasticMQ, Akka and Netty to reduce the amount of unnecessary log messages being published -->
+    <logger name="org.elasticmq" level="OFF" />
+    <logger name="akka" level="OFF" />
+    <logger name="io.netty" level="ERROR" />
+
+    <logger name="com.jashmore" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/ktor/core/build.gradle.kts
+++ b/ktor/core/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+description = "Library for integrating the Java Dynamic Sqs Listener in a Ktor application"
+
+plugins {
+    kotlin("jvm") version "1.3.72"
+}
+
+repositories {
+    jcenter()
+}
+
+apply(plugin = "kotlin")
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    api(project(":java-dynamic-sqs-listener-core"))
+    api(project(":core-kotlin-dsl"))
+    implementation("io.ktor:ktor-server-core:1.3.2")
+
+    testImplementation(project(":elasticmq-sqs-client"))
+    testImplementation(project(":expected-test-exception"))
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("io.ktor:ktor-server-test-host:1.3.2")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/ktor/core/src/main/kotlin/com/jashmore/sqs/ktor/container/KtorCoreExtension.kt
+++ b/ktor/core/src/main/kotlin/com/jashmore/sqs/ktor/container/KtorCoreExtension.kt
@@ -1,0 +1,51 @@
+package com.jashmore.sqs.ktor.container
+
+import com.jashmore.sqs.container.MessageListenerContainer
+import com.jashmore.sqs.core.kotlin.dsl.container.BatchingMessageListenerContainerBuilder
+import com.jashmore.sqs.core.kotlin.dsl.container.CoreMessageListenerContainerBuilder
+import com.jashmore.sqs.core.kotlin.dsl.container.PrefetchingMessageListenerContainerBuilder
+import com.jashmore.sqs.core.kotlin.dsl.container.coreMessageListener
+import io.ktor.application.Application
+import io.ktor.application.ApplicationEnvironment
+import io.ktor.application.ApplicationStarted
+import io.ktor.application.ApplicationStopped
+import io.ktor.util.pipeline.ContextDsl
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+
+@ContextDsl
+fun Application.messageListener(identifier: String,
+                                sqsAsyncClient: SqsAsyncClient,
+                                queueUrl: String,
+                                config: CoreMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return initMessageListener(environment, coreMessageListener(identifier, sqsAsyncClient, queueUrl, config))
+}
+
+@ContextDsl
+fun Application.prefetchingMessageListener(identifier: String,
+                                           sqsAsyncClient: SqsAsyncClient,
+                                           queueUrl: String,
+                                           init: PrefetchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return initMessageListener(environment, com.jashmore.sqs.core.kotlin.dsl.container.prefetchingMessageListener(identifier, sqsAsyncClient, queueUrl, init))
+}
+
+@ContextDsl
+fun Application.batchingMessageListener(identifier: String,
+                                        sqsAsyncClient: SqsAsyncClient,
+                                        queueUrl: String,
+                                        init: BatchingMessageListenerContainerBuilder.() -> Unit): MessageListenerContainer {
+    return initMessageListener(environment, com.jashmore.sqs.core.kotlin.dsl.container.batchingMessageListener(identifier, sqsAsyncClient, queueUrl, init))
+}
+
+
+fun initMessageListener(environment: ApplicationEnvironment,
+                        container: MessageListenerContainer): MessageListenerContainer {
+    environment.monitor.subscribe(ApplicationStarted) {
+        container.start()
+    }
+
+    environment.monitor.subscribe(ApplicationStopped) {
+        container.stop()
+    }
+
+    return container
+}

--- a/ktor/core/src/test/kotlin/com/jashmore/sqs/ktor/container/KtorCoreExtensionTest.kt
+++ b/ktor/core/src/test/kotlin/com/jashmore/sqs/ktor/container/KtorCoreExtensionTest.kt
@@ -1,0 +1,108 @@
+package com.jashmore.sqs.ktor.container
+
+import com.jashmore.sqs.elasticmq.ElasticMqSqsAsyncClient
+import com.jashmore.sqs.util.LocalSqsAsyncClient
+import io.ktor.application.log
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.testing.withTestApplication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private val sqsClient: LocalSqsAsyncClient = ElasticMqSqsAsyncClient()
+
+@AfterAll
+fun tearDown() {
+    sqsClient.close()
+}
+
+class KtorCoreExtensionTest {
+    @Test
+    fun `message listener can be registered`() {
+        val queueUrl = sqsClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+        withTestApplication({
+            val server = embeddedServer(Netty, 8080) {
+                messageListener("core-listener", sqsClient, queueUrl) {
+                    processor = lambdaProcessor {
+                        method { message ->
+                            log.info("Message: {}", message.body())
+                            countDownLatch.countDown()
+                        }
+                    }
+                    retriever = batchingMessageRetriever {
+                        batchSize = { 1 }
+                        batchingPeriod = { Duration.ofSeconds(30) }
+                    }
+                    resolver = batchingResolver {
+                        batchSize = { 1 }
+                        batchingPeriod = { Duration.ofSeconds(5) }
+                    }
+                    broker = concurrentBroker {
+                        concurrencyLevel = { 5 }
+                        concurrencyPollingRate = { Duration.ofMinutes(1) }
+                    }
+                }
+            }
+            server.start()
+        }) {
+            sqsClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }.get()
+
+            assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+    }
+
+    @Test
+    fun `prefetching message listener can be registered`() {
+        val queueUrl = sqsClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+        withTestApplication({
+            val server = embeddedServer(Netty, 8080) {
+                prefetchingMessageListener("prefetching-listener", sqsClient, queueUrl) {
+                    concurrencyLevel = { 5 }
+                    desiredPrefetchedMessages = 1
+                    maxPrefetchedMessages = 2
+                    processor = lambdaProcessor {
+                        method { message ->
+                            log.info("Message: {}", message.body())
+                            countDownLatch.countDown()
+                        }
+                    }
+                }
+            }
+            server.start()
+        }) {
+            sqsClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }.get()
+
+            assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+    }
+
+    @Test
+    fun `batching message listener can be registered`() {
+        val queueUrl = sqsClient.createRandomQueue().get().queueUrl()
+        val countDownLatch = CountDownLatch(1)
+        withTestApplication({
+            val server = embeddedServer(Netty, 8080) {
+                batchingMessageListener("batching-listener", sqsClient, queueUrl) {
+                    concurrencyLevel = { 5 }
+                    processor = lambdaProcessor {
+                        method { message ->
+                            log.info("Message: {}", message.body())
+                            countDownLatch.countDown()
+                        }
+                    }
+                }
+            }
+            server.start()
+        }) {
+            sqsClient.sendMessage { it.queueUrl(queueUrl).messageBody("body") }.get()
+
+            assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+    }
+}

--- a/ktor/core/src/test/resources/logback.xml
+++ b/ktor/core/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- We reduce the log messages from ElasticMQ, Akka and Netty to reduce the amount of unnecessary log messages being published -->
+    <logger name="org.elasticmq" level="OFF" />
+    <logger name="akka" level="OFF" />
+    <logger name="io.netty" level="ERROR" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,9 @@ include(
         ":java-dynamic-sqs-listener-spring-api",
         ":java-dynamic-sqs-listener-spring-core",
         ":java-dynamic-sqs-listener-spring-starter",
+
+        // Ktor
+        ":java-dynamic-sqs-listener-ktor-core",
         
         // Extensions
         ":aws-xray-extension-core",
@@ -50,6 +53,7 @@ include(
         ":example:core-example",
         ":example:spring-aws-example",
         ":example:core-kotlin-example",
+        ":example:ktor-example",
         ":example:spring-cloud-schema-registry:consumer",
         ":example:spring-cloud-schema-registry:producer",
         ":example:spring-cloud-schema-registry:producer-two",
@@ -76,6 +80,7 @@ project(":aws-xray-extension-spring-boot").projectDir = file("extensions/aws-xra
 project(":brave-extension-core").projectDir = file("extensions/brave-extension/core")
 project(":brave-extension-spring-boot").projectDir = file("extensions/brave-extension/spring-boot")
 project(":core-kotlin-dsl").projectDir = file("extensions/core-kotlin-dsl")
+project(":java-dynamic-sqs-listener-ktor-core").projectDir = file("ktor/core")
 project(":spring-cloud-schema-registry-extension-api").projectDir = file("extensions/spring-cloud-schema-registry-extension/spring-cloud-schema-registry-extension-api")
 project(":avro-spring-cloud-schema-registry-extension").projectDir = file("extensions/spring-cloud-schema-registry-extension/avro-spring-cloud-schema-registry-extension")
 project(":in-memory-spring-cloud-schema-registry").projectDir = file("extensions/spring-cloud-schema-registry-extension/in-memory-spring-cloud-schema-registry")
@@ -95,6 +100,7 @@ project(":sqs-brave-tracing").projectDir = file("util/sqs-brave-tracing")
 project(":example:aws-xray-spring-example").projectDir = file("examples/aws-xray-spring-example")
 project(":example:core-example").projectDir = file("examples/core-example")
 project(":example:core-kotlin-example").projectDir = file("examples/core-kotlin-example")
+project(":example:ktor-example").projectDir = file("examples/ktor-example")
 project(":example:spring-aws-example").projectDir = file("examples/spring-aws-example")
 project(":example:spring-cloud-schema-registry:consumer").projectDir = file("examples/spring-cloud-schema-registry-example/spring-cloud-schema-registry-consumer")
 project(":example:spring-cloud-schema-registry:producer").projectDir = file("examples/spring-cloud-schema-registry-example/spring-cloud-schema-registry-producer")


### PR DESCRIPTION
Can now register message listeners in a Ktor application by using the
Ktor Core module.

Usage would look like:

```kotlin
val server = embeddedServer(Netty, 8080) {
    prefetchingMessageListener("prefetching-listener", sqsAsyncClient,
"queueUrl") {
        concurrencyLevel = { 2 }
        desiredPrefetchedMessages = 5
        maxPrefetchedMessages = 10

        processor = lambdaProcessor {
            method { message ->
               log.info("Message: {}", message.body())
            }
        }
   }
}
```