### PR TITLE
refs #273: Allow configuration of container startup when spring starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ More in-depth guides on how configure this library:
     queue listening without the verbosity of a custom queue listener
     1. [How to write Spring Integration Tests](doc/how-to-guides/spring/spring-how-to-write-integration-tests.md): you actually want to test what you are
     writing right?
+    1. [How to prevent listeners from starting on startup](doc/how-to-guides/spring/spring-how-to-prevent-containers-starting-on-startup.md): guide for
+    preventing containers from starting when the Spring application has started up.
     1. [How to Start/Stop Queue Listeners](doc/how-to-guides/spring/spring-how-to-start-stop-message-listener-containers.md): guide for starting and stopping the
     processing of messages for specific queue listeners
     1. [How to connect to multiple AWS Accounts](doc/how-to-guides/spring/spring-how-to-connect-to-multiple-aws-accounts.md): guide for listening to queues

--- a/doc/how-to-guides/spring/spring-how-to-prevent-containers-starting-on-startup.md
+++ b/doc/how-to-guides/spring/spring-how-to-prevent-containers-starting-on-startup.md
@@ -1,0 +1,27 @@
+# Spring - How to prevent Message Listener Containers starting on startup
+
+By default, a [DefaultMessageListenerCoordinator](../../../spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinator.java)
+is configured to discover containers as well as start and stop the containers in the Spring Lifecycle. This will auto startup the containers by default but,
+if this is not desirable, you can supply your own properties to disable this functionality.
+
+## Steps
+
+1. Define your own
+[DefaultMessageListenerCoordinatorProperties](../../../spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinatorProperties.java)
+with the configuration you desire.
+
+    ```java
+    @Configuration
+    class MyConfiguration {
+        @Bean
+        DefaultMessageListenerCoordinatorProperties defaultMessageListenerCoordinatorProperties() {
+             return StaticDefaultMessageListenerContainerCoordinatorProperties.builder()
+                         .isAutoStartContainersEnabled(false)
+                         .build();
+        }
+    }
+    ```
+
+This will not work if you have supplied your
+own [MessageListenerContainerCoordinator](../../../spring/spring-api/src/main/java/com/jashmore/sqs/spring/container/MessageListenerContainerCoordinator.java)
+bean as the default coordinator will now not be configured for you anymore.

--- a/spring/spring-api/src/main/java/com/jashmore/sqs/spring/container/MessageListenerContainerCoordinator.java
+++ b/spring/spring-api/src/main/java/com/jashmore/sqs/spring/container/MessageListenerContainerCoordinator.java
@@ -1,10 +1,21 @@
 package com.jashmore.sqs.spring.container;
 
+import com.jashmore.sqs.container.MessageListenerContainer;
+
+import java.util.Set;
+
 /**
  * Service that can be injected into the Spring Application to start and stop the containers that are controlling
  * the consumption of queue messages.
  */
 public interface MessageListenerContainerCoordinator {
+    /**
+     * Get all of the containers that have been configured with this coordinator.
+     *
+     * @return the set of containers
+     */
+    Set<MessageListenerContainer> getContainers();
+
     /**
      * Start all of the containers that have been built for the application.
      */

--- a/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinatorProperties.java
+++ b/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinatorProperties.java
@@ -1,0 +1,12 @@
+package com.jashmore.sqs.spring.container;
+
+import com.jashmore.sqs.container.MessageListenerContainer;
+
+public interface DefaultMessageListenerContainerCoordinatorProperties {
+    /**
+     * Determine if the {@link MessageListenerContainer}s should be started up by default when the Spring Container starts up.
+     *
+     * @return whether the containers will be started on startup
+     */
+    boolean isAutoStartContainersEnabled();
+}

--- a/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/StaticDefaultMessageListenerContainerCoordinatorProperties.java
+++ b/spring/spring-core/src/main/java/com/jashmore/sqs/spring/container/StaticDefaultMessageListenerContainerCoordinatorProperties.java
@@ -1,0 +1,18 @@
+package com.jashmore.sqs.spring.container;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Provides the properties as static values that never change.
+ */
+@Value
+@Builder(toBuilder = true)
+public class StaticDefaultMessageListenerContainerCoordinatorProperties implements DefaultMessageListenerContainerCoordinatorProperties {
+    boolean isAutoStartContainersEnabled;
+
+    @Override
+    public boolean isAutoStartContainersEnabled() {
+        return isAutoStartContainersEnabled;
+    }
+}

--- a/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinatorTest.java
+++ b/spring/spring-core/src/test/java/com/jashmore/sqs/spring/container/DefaultMessageListenerContainerCoordinatorTest.java
@@ -27,13 +27,16 @@ import java.util.Collections;
 @ExtendWith(MockitoExtension.class)
 class DefaultMessageListenerContainerCoordinatorTest {
     @Mock
+    private DefaultMessageListenerContainerCoordinatorProperties properties;
+
+    @Mock
     private ApplicationContext applicationContext;
 
     @Test
     void whenNoMessageListenerContainerFactoriesPresentBeansAreNotProcessed() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
 
         // act
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
@@ -48,7 +51,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         // arrange
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] {});
 
         // act
@@ -67,7 +70,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(messageListenerContainerFactory.canHandleMethod(method)).thenReturn(true);
         final MessageListenerContainer container = mock(MessageListenerContainer.class);
@@ -90,7 +93,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] {"bean"});
         when(applicationContext.getBean("bean")).thenReturn(bean);
@@ -110,7 +113,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method methodOne = bean.getClass().getMethod("methodOne");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
 
         when(messageListenerContainerFactory.canHandleMethod(methodOne)).thenReturn(true);
@@ -139,7 +142,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(messageListenerContainerFactory.canHandleMethod(method)).thenReturn(true);
         final MessageListenerContainer container = mock(MessageListenerContainer.class);
@@ -165,7 +168,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(messageListenerContainerFactory.canHandleMethod(method)).thenReturn(true);
         final MessageListenerContainer container = mock(MessageListenerContainer.class);
@@ -192,7 +195,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void stoppingContainerThatDoesNotExistThrowsIllegalArgumentException() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
 
         // act
@@ -206,7 +209,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(messageListenerContainerFactory.canHandleMethod(method)).thenReturn(true);
         final MessageListenerContainer container = mock(MessageListenerContainer.class);
@@ -227,7 +230,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void startingContainerThatDoesNotExistThrowsIllegalArgumentException() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
 
         // act
@@ -241,7 +244,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
         final Method method = bean.getClass().getMethod("method");
         final MessageListenerContainerFactory messageListenerContainerFactory = mock(MessageListenerContainerFactory.class);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator
-                = new DefaultMessageListenerContainerCoordinator(Collections.singletonList(messageListenerContainerFactory));
+                = new DefaultMessageListenerContainerCoordinator(properties, Collections.singletonList(messageListenerContainerFactory));
         when(messageListenerContainerFactory.canHandleMethod(any(Method.class))).thenReturn(false);
         when(messageListenerContainerFactory.canHandleMethod(method)).thenReturn(true);
         final MessageListenerContainer container = mock(MessageListenerContainer.class);
@@ -259,20 +262,24 @@ class DefaultMessageListenerContainerCoordinatorTest {
     }
 
     @Test
-    void autoStartsService() {
+    void configuredPropertiesWillDetermineIfContainerIsAutostartup() {
         // arrange
+        when(properties.isAutoStartContainersEnabled())
+                .thenReturn(true)
+                .thenReturn(false);
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
 
         // assert
         assertThat(defaultMessageListenerContainerCoordinator.isAutoStartup()).isTrue();
+        assertThat(defaultMessageListenerContainerCoordinator.isAutoStartup()).isFalse();
     }
 
     @Test
     void startLifeCycleStartsAllContainers() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                spy(new DefaultMessageListenerContainerCoordinator(emptyList()));
+                spy(new DefaultMessageListenerContainerCoordinator(properties, emptyList()));
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
 
         // act
@@ -286,7 +293,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void stopLifeCycleStopsAllContainers() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                spy(new DefaultMessageListenerContainerCoordinator(emptyList()));
+                spy(new DefaultMessageListenerContainerCoordinator(properties, emptyList()));
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
 
         // act
@@ -300,7 +307,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void stopLifeCycleWithCallbackStartsAllContainersAndRunsCallback() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                spy(new DefaultMessageListenerContainerCoordinator(emptyList()));
+                spy(new DefaultMessageListenerContainerCoordinator(properties, emptyList()));
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
         final Runnable callback = mock(Runnable.class);
 
@@ -316,7 +323,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void beanIsNotRunningWhenStartIsNotCalled() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
 
         // assert
         assertThat(defaultMessageListenerContainerCoordinator.isRunning()).isFalse();
@@ -326,7 +333,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void startLifeCycleSetsBeanAsRunning() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
         assertThat(defaultMessageListenerContainerCoordinator.isRunning()).isFalse();
 
@@ -341,7 +348,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void stopLifeCycleSetsBeanAsNotRunning() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
         defaultMessageListenerContainerCoordinator.setApplicationContext(applicationContext);
         assertThat(defaultMessageListenerContainerCoordinator.isRunning()).isFalse();
         defaultMessageListenerContainerCoordinator.start();
@@ -357,7 +364,7 @@ class DefaultMessageListenerContainerCoordinatorTest {
     void beanShouldBeStartedLast() {
         // arrange
         final DefaultMessageListenerContainerCoordinator defaultMessageListenerContainerCoordinator =
-                new DefaultMessageListenerContainerCoordinator(emptyList());
+                new DefaultMessageListenerContainerCoordinator(properties, emptyList());
 
         // assert
         assertThat(defaultMessageListenerContainerCoordinator.getPhase()).isEqualTo(Integer.MAX_VALUE);


### PR DESCRIPTION
Also adds a `MessageListenerContainerCoordinator#getContainers()` method
so consumers can get all the containers if they desire.